### PR TITLE
fix call to setTrustStorePassword

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -31,7 +31,7 @@
     (when (options :truststore)
       (.setTrustStore context (options :truststore)))
     (when (options :trust-password)
-      (.setTrustPassword context (options :trust-password)))
+      (.setTrustStorePassword context (options :trust-password)))
     (case (options :client-auth)
       :need (.setNeedClientAuth context true)
       :want (.setWantClientAuth context true)


### PR DESCRIPTION
There was a typo in the method name:

http://download.eclipse.org/jetty/stable-7/apidocs/org/eclipse/jetty/util/ssl/SslContextFactory.html#setTrustStorePassword(java.lang.String)
