### PR TITLE
Fix for error thrown by double-escape when encoded dollar-sign is decoded.

### DIFF
--- a/ring-core/src/ring/util/codec.clj
+++ b/ring-core/src/ring/util/codec.clj
@@ -8,7 +8,7 @@
            org.apache.commons.codec.binary.Base64))
 
 (defn- double-escape [^String x]
-  (.replace x "\\" "\\\\"))
+  (.replace (.replace x "\\" "\\\\") "$" "\\$"))
 
 (defn percent-encode
   "Percent-encode every character in the given string using either the specified

--- a/ring-core/test/ring/util/test/codec.clj
+++ b/ring-core/test/ring/util/test/codec.clj
@@ -11,7 +11,8 @@
 (deftest test-percent-decode
   (is (= (percent-decode "%20") " "))
   (is (= (percent-decode "foo%20bar") "foo bar"))
-  (is (= (percent-decode "foo%FE%FF%00%2Fbar" "UTF-16") "foo/bar")))
+  (is (= (percent-decode "foo%FE%FF%00%2Fbar" "UTF-16") "foo/bar"))
+  (is (= (percent-decode "%24") "$")))
 
 (deftest test-url-encode
   (is (= (url-encode "foo/bar") "foo%2Fbar"))


### PR DESCRIPTION
util/codec.clj: fixed handling of $ in double-escape. Decoding of %24 into $ then caused index-out-of-bounds error as $ has special meaning
in regexes.
