### PR TITLE
Extended nested keys syntax to allow indexing into nested vectors

### DIFF
--- a/ring-core/src/ring/middleware/nested_params.clj
+++ b/ring-core/src/ring/middleware/nested_params.clj
@@ -5,7 +5,12 @@
   "Parse a parameter name into a list of keys using a 'C'-like index
   notation. e.g.
     \"foo[bar][][baz]\"
-    => [\"foo\" \"bar\" \"\" \"baz\"]"
+    => [\"foo\" \"bar\" \"\" \"baz\"]
+
+   If the parameter name starts with '[', it will be passed to read-string
+   to parse into a vector. The vector may contain numbers which will be
+   treated as indexes into nested vectors. e.g.
+     \"[:parents 1 :children 0 :name]\""
   [param-name]
   (if (= (first param-name) \[)
     (read-string param-name)
@@ -15,7 +20,7 @@
 
 (defn- assoc-nested
   "Similar to assoc-in, but treats values of blank keys as elements in a
-  list."
+  list. Numbers are treated as indexes into nested vectors."
   [m [k & ks] v]
   (conj m
         (if k

--- a/ring-core/test/ring/middleware/test/nested_params.clj
+++ b/ring-core/test/ring/middleware/test/nested_params.clj
@@ -15,4 +15,28 @@
         {"foo[]" "bar"}         {"foo" ["bar"]}
         {"foo[]" ["bar" "baz"]} {"foo" ["bar" "baz"]}
         {"a[x][]" ["b"], "a[x][][y]" "c"} {"a" {"x" ["b" {"y" "c"}]}}
-        {"a[][x]" "c", "a[][y]" "d"}      {"a" [{"x" "c"} {"y" "d"}]}))))
+        {"a[][x]" "c", "a[][y]" "d"}      {"a" [{"x" "c"} {"y" "d"}]}))
+    (testing "nested parameter path without indexes"
+      (are [p r] (= (handler {:params p}) r)
+           {"[:foo]" "bar"} {:foo "bar"}
+           {"[:x :y]" "z"} {:x {:y "z"}}
+           {"[:a :b :c]" "d"} {:a {:b {:c "d"}}}
+           {"[:a]" "b", "[:c]" "d"} {:a "b", :c "d"}
+           ))
+    (testing "nested parameter path with indexes"
+      (are [p r] (= (handler {:params p}) r)
+           {"[:parents 0 :id]" "1"} {:parents [{:id "1"}]}
+           {"[:parents 1 :id]" "1"} {:parents [nil {:id "1"}]}
+           {"[:parents 0 :children 0 :grandchildren 0 :id]" "1"} {:parents [{:children [{:grandchildren [{:id "1"}]}]}]}
+           {"[:parents 0 :children 0 :grandchildren 0 :id]" "1"
+            "[:parents 0 :children 0 :grandchildren 1 :id]" "2"
+            "[:parents 0 :children 1 :grandchildren 0 :id]" "3"
+            "[:parents 0 :children 0 :id]" "4"
+            "[:parents 0 :children 1 :id]" "5"
+            "[:parents 0 :id]" "6"}
+           {:parents
+            [{:id "6"
+              :children [{:id "4"
+                          :grandchildren [{:id "1"} {:id "2"}]}
+                         {:id "5"
+                          :grandchildren [{:id "3"}]}]}]}))))


### PR DESCRIPTION
A nested key that starts with '[' is passed to read-string and should return a vector. Numbers in that key vector are treated as indexes into nested vectors.

{"[:parents 0 :children 0 :grandchildren 0 :id]" "1"} => {:parents [{:children [{:grandchildren [{:id "1"}]}]}]}

This should have minimal impact on existing code since the existing parser takes "[parents]" and returns ["" "parents"], which seems to be a degenerate case. 

{"[:parents 0 :children 0 :grandchildren 0 :id]" "1"
            "[:parents 0 :children 0 :grandchildren 1 :id]" "2"
            "[:parents 0 :children 1 :grandchildren 0 :id]" "3"
            "[:parents 0 :children 0 :id]" "4"
            "[:parents 0 :children 1 :id]" "5"
            "[:parents 0 :id]" "6"}
=> {:parents
            [{:id "6"
              :children [{:id "4"
                          :grandchildren [{:id "1"} {:id "2"}]}
                         {:id "5"
                          :grandchildren [{:id "3"}]}]}]}
