### PR TITLE
Add context middleware

### DIFF
--- a/ring-core/src/ring/middleware/context.clj
+++ b/ring-core/src/ring/middleware/context.clj
@@ -1,0 +1,19 @@
+(ns ring.middleware.context
+  "Middleware for making a handler behave like it is a context handler."
+  (:require [clojure.string :refer [split]]))
+
+(defn wrap-context
+  "Middleware that makes a handler behave like a context handler. This means
+  that it splits the :uri putting the first segment in :context and the rest
+  in :path-info. The context without the leading / is passed to match-context?
+  to determine if the handler should be called at all. In this way, multiple
+  context handlers can be combined."
+  ([handler]
+     (wrap-context handler (constantly true)))
+  ([handler match-context?]
+     (fn [request]
+       (let [[_ context path-info] (split (:uri request) #"/" 3)]
+         (when (match-context? context)
+           (handler (assoc request
+                      :context (str "/" context)
+                      :path-info (str "/" path-info))))))))


### PR DESCRIPTION
This wraps a handler so that it behaves like it is inside a
ServletContext, splitting :uri and filling in the :context and
:path-info fields in request. This will be used in to allow an option in
lein-ring so that 'lein ring server' behaves like a container.
