### PR TITLE
Remove reflection warnings in ring-core

### DIFF
--- a/ring-core/src/ring/middleware/multipart_params/byte_array.clj
+++ b/ring-core/src/ring/middleware/multipart_params/byte_array.clj
@@ -11,4 +11,4 @@
   []
   (fn [item]
     (-> (select-keys item [:filename :content-type])
-        (assoc :bytes (IOUtils/toByteArray (:stream item))))))
+        (assoc :bytes (IOUtils/toByteArray ^java.io.InputStream (:stream item))))))

--- a/ring-core/src/ring/middleware/multipart_params/temp_file.clj
+++ b/ring-core/src/ring/middleware/multipart_params/temp_file.clj
@@ -2,7 +2,7 @@
   (:require [clojure.java.io :as io])
   (:import java.io.File))
 
-(defn- background-thread [f]
+(defn- background-thread [^Runnable f]
   (doto (Thread. f)
     (.setDaemon true)
     (.start)))

--- a/ring-core/src/ring/middleware/not_modified.clj
+++ b/ring-core/src/ring/middleware/not_modified.clj
@@ -8,7 +8,7 @@
   (if-let [etag (get-in response [:headers "etag"])]
     (= etag (get-in request [:headers "if-none-match"]))))
 
-(defn- date-header [response header]
+(defn- ^java.util.Date date-header [response header]
   (if-let [http-date (get-in response [:headers header])]
     (parse-date http-date)))
 

--- a/ring-core/src/ring/util/codec.clj
+++ b/ring-core/src/ring/util/codec.clj
@@ -13,7 +13,7 @@
 (defn percent-encode
   "Percent-encode every character in the given string using either the specified
   encoding, or UTF-8 by default."
-  [unencoded & [encoding]]
+  [^String unencoded & [^String encoding]]
   (->> (.getBytes unencoded (or encoding "UTF-8"))
        (map (partial format "%%%02X"))
        (str/join)))
@@ -21,17 +21,17 @@
 (defn- parse-bytes [encoded-bytes]
   (->> (re-seq #"%.." encoded-bytes)
        (map #(subs % 1))
-       (map #(.byteValue (Integer/parseInt % 16)))
+       (map #(.byteValue (Integer/valueOf % 16)))
        (byte-array)))
 
 (defn percent-decode
   "Decode every percent-encoded character in the given string using the
   specified encoding, or UTF-8 by default."
-  [encoded & [encoding]]
+  [^String encoded & [^String encoding]]
   (str/replace encoded
                #"(?:%..)+"
                (fn [chars]
-                 (-> (parse-bytes chars)
+                 (-> ^bytes (parse-bytes chars)
                      (String. (or encoding "UTF-8"))
                      (double-escape)))))
 
@@ -44,7 +44,7 @@
     #"[^A-Za-z0-9_~.+-]+"
     #(double-escape (percent-encode % encoding))))
 
-(defn url-decode
+(defn ^String url-decode
   "Returns the url-decoded version of the given string, using either a specified
   encoding or UTF-8 by default. If the encoding is invalid, nil is returned."
   [encoded & [encoding]]
@@ -101,7 +101,7 @@
   "Decode the supplied www-form-urlencoded string using the specified encoding,
   or UTF-8 by default. If the encoded value is a string, a string is returned.
   If the encoded value is a map of parameters, a map is returned."
-  [encoded & [encoding]]
+  [^String encoded & [encoding]]
   (if-not (.contains encoded "=")
     (form-decode-str encoded encoding)
     (reduce

--- a/ring-core/src/ring/util/io.clj
+++ b/ring-core/src/ring/util/io.clj
@@ -29,7 +29,7 @@
   "Returns a ByteArrayInputStream for the given String."
   ([^String s]
      (ByteArrayInputStream. (.getBytes s)))
-  ([^String s encoding]
+  ([^String s ^String encoding]
      (ByteArrayInputStream. (.getBytes s encoding))))
 
 (defn close!
@@ -37,5 +37,5 @@
   [stream]
   (when (instance? java.io.Closeable stream)
     (try
-      (.close stream)
+      (.close ^java.io.Closeable stream)
       (catch IOException _ nil))))

--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -96,12 +96,12 @@
 ;; As a work-around, we'll backport the fix from the Clojure master
 ;; branch into url-as-file.
 
-(defn- url-as-file [u]
+(defn- ^File url-as-file [^java.net.URL u]
   (io/as-file
    (str/replace
     (.replace (.getFile u) \/ File/separatorChar)
     #"%.."
-    (fn [escape]
+    (fn [^String escape]
       (-> escape
           (.substring 1 3)
           (Integer/parseInt 16)

--- a/ring-core/src/ring/util/time.clj
+++ b/ring-core/src/ring/util/time.clj
@@ -11,8 +11,8 @@
    :rfc1036 "EEEE, dd-MMM-yy HH:mm:ss zzz"
    :asctime "EEE MMM d HH:mm:ss yyyy"})
 
-(defn- formatter [format]
-  (doto (SimpleDateFormat. (http-date-formats format) Locale/US)
+(defn- ^SimpleDateFormat formatter [format]
+  (doto (SimpleDateFormat. ^String (http-date-formats format) Locale/US)
     (.setTimeZone (TimeZone/getTimeZone "GMT"))))
 
 (defn- attempt-parse [date format]

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -26,10 +26,10 @@
   (let [context (SslContextFactory.)]
     (if (string? (options :keystore))
       (.setKeyStorePath context (options :keystore))
-      (.setKeyStore context (options :keystore)))
+      (.setKeyStore context ^java.security.KeyStore (options :keystore)))
     (.setKeyStorePassword context (options :key-password))
     (when (options :truststore)
-      (.setTrustStore context (options :truststore)))
+      (.setTrustStore context ^java.security.KeyStore (options :truststore)))
     (when (options :trust-password)
       (.setTrustStorePassword context (options :trust-password)))
     (case (options :client-auth)
@@ -78,7 +78,7 @@
                   :want or :none (defaults to :none)"
   [handler options]
   (let [^Server s (create-server (dissoc options :configurator))
-        ^QueuedThreadPool p (QueuedThreadPool. (options :max-threads 50))]
+        ^QueuedThreadPool p (QueuedThreadPool. ^Integer (options :max-threads 50))]
     (when (:daemon? options false)
       (.setDaemon p true))
     (doto s


### PR DESCRIPTION
Remove all reflection warnings in clojure-core. All test pass.
The only reflection warnings left are ones from clj-time.core and clj-time.format
