### PR TITLE
Beef up test coverage for ring-jetty-adapter

### DIFF
--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -17,6 +17,11 @@
     :headers {"Content-Type" content-type}
     :body    ""}))
 
+(defn- echo-handler [request]
+  {:status 200
+   :headers {"request-map" (str (dissoc request :body))}
+   :body (:body request)})
+
 (defmacro with-server [app options & body]
   `(let [server# (run-jetty ~app ~(assoc options :join? false))]
      (try
@@ -81,4 +86,22 @@
     (with-server (content-type-handler "text/plain;charset=UTF-16;version=1") {:port 4347}
       (let [response (http/get "http://localhost:4347")]
         (is (= (get-in response [:headers "content-type"])
-               "text/plain;charset=UTF-16;version=1"))))))
+               "text/plain;charset=UTF-16;version=1")))))
+
+  (testing "request translation"
+    (with-server echo-handler {:port 4347}
+      (let [response (http/get "http://localhost:4347/foo/bar/baz?surname=jones&age=123" {:body "hello"})]
+        (is (= (:status response) 200))
+        (is (= (:body response) "hello"))
+        (let [request-map (read-string (get-in response [:headers "request-map"]))]
+          (is (= (:query-string request-map) "surname=jones&age=123"))
+          (is (= (:uri request-map) "/foo/bar/baz"))
+          (is (= (:content-length request-map) 5))
+          (is (= (:character-encoding request-map) "UTF-8"))
+          (is (= (:request-method request-map) :get))
+          (is (= (:content-type request-map) "text/plain; charset=UTF-8"))
+          (is (= (:remote-addr request-map) "127.0.0.1"))
+          (is (= (:scheme request-map) :http))
+          (is (= (:server-name request-map) "localhost"))
+          (is (= (:server-port request-map) 4347))
+          (is (= (:ssl-client-cert request-map) nil)))))))


### PR DESCRIPTION
Whilst implementing a new ring adapter for simpleweb (https://github.com/netmelody/ring-simpleweb-adapter), I created a new unit test to check that I was correctly translating the properties of the incoming requests to a ring request map compliant with the ring SPEC.  I felt that the ring-jetty-adapter would also benefit from this test coverage, so here it is!
