### PR TITLE
Set default content-length to -1

### DIFF
--- a/ring-core/src/ring/middleware/multipart_params.clj
+++ b/ring-core/src/ring/middleware/multipart_params.clj
@@ -20,7 +20,7 @@
   [request encoding]
   (reify RequestContext
     (getContentType [this]       (:content-type request))
-    (getContentLength [this]     (:content-length request))
+    (getContentLength [this]     (or (:content-length request) -1))
     (getCharacterEncoding [this] encoding)
     (getInputStream [this]       (:body request))))
 

--- a/ring-core/src/ring/middleware/multipart_params/request_context.clj
+++ b/ring-core/src/ring/middleware/multipart_params/request_context.clj
@@ -1,0 +1,7 @@
+(ns ring.middleware.multipart-params.test.request-context
+  (:use clojure.test)
+  (:require [ring.middleware.multipart-params :as mp]))
+
+(deftest test-default-content-length
+  (is (= -1
+         (.getContentLength (#'mp/request-context {} nil)))))


### PR DESCRIPTION
We were having `NullPointerException` trouble when handling chunked file uploads due to the fact that `:content-length` was missing from the request. This patch defaults [RequestContext.getContentLength()](http://commons.apache.org/fileupload/apidocs/org/apache/commons/fileupload/RequestContext.html#getContentLength%28%29) to -1 which is what [ServletRequest.getContentLength()](http://docs.oracle.com/javaee/6/api/javax/servlet/ServletRequest.html#getContentLength%28%29) does.

Here's the interesting part of the stacktrace we were getting in case you're interested:

```
java.lang.NullPointerException
   at ring.middleware.multipart_params$request_context$reify__4928.getContentLength(multipart_params.clj:23)
   at org.apache.commons.fileupload.FileUploadBase$FileItemIteratorImpl.<init>(FileUploadBase.java:936)
   at org.apache.commons.fileupload.FileUploadBase.getItemIterator(FileUploadBase.java:331)
   at ring.middleware.multipart_params$file_item_seq.invoke(multipart_params.clj:38)
   at ring.middleware.multipart_params$parse_multipart_params.invoke(multipart_params.clj:54)
   at ring.middleware.multipart_params$wrap_multipart_params$fn__4948.invoke(multipart_params.clj:98)
   at ring.middleware.params$wrap_params$fn__4844.invoke(params.clj:55)
```
