### PR TITLE
small patch to support immutant static assets.

### DIFF
--- a/ring-core/src/ring/middleware/resource.clj
+++ b/ring-core/src/ring/middleware/resource.clj
@@ -7,11 +7,14 @@
   "Middleware that first checks to see whether the request map matches a static
   resource. If it does, the resource is returned in a response map, otherwise
   the request map is passed onto the handler. The root-path argument will be
-  added to the beginning of the resource path."
-  [handler root-path]
-  (fn [request]
-    (if-not (= :get (:request-method request))
-      (handler request)
-      (let [path (.substring (codec/url-decode (:uri request)) 1)]
-        (or (response/resource-response path {:root root-path})
-            (handler request))))))
+  added to the beginning of the resource path. Also supports optional parameter
+  to use a key other than :uri, for example :path-info for immutant support."
+  ([handler root-path]
+     (wrap-resource handler root-path :uri))
+  ([handler root-path path-key]
+     (fn [request]
+       (if-not (= :get (:request-method request))
+         (handler request)
+         (let [path (.substring (codec/url-decode (path-key request)) 1)]
+           (or (response/resource-response path {:root root-path})
+               (handler request)))))))

--- a/ring-core/test/ring/middleware/test/resource.clj
+++ b/ring-core/test/ring/middleware/test/resource.clj
@@ -16,3 +16,12 @@
       {:request-method :get, :uri "/bars/foo.html"} "foo"
       {:request-method :get, :uri "/handler"}       "handler"
       {:request-method :post, :uri "/foo.html"}     "handler")))
+
+(deftest resource-test-additional-param
+  (let [handler (wrap-resource test-handler "/ring/assets" :path-info)]
+    (are [request body] (= (slurp (:body (handler request))) body)
+      {:request-method :get, :path-info "/foo.html"}      "foo"
+      {:request-method :get, :path-info "/index.html"}    "index"
+      {:request-method :get, :path-info "/bars/foo.html"} "foo"
+      {:request-method :get, :path-info "/handler"}       "handler"
+      {:request-method :post, :path-info "/foo.html"}     "handler")))


### PR DESCRIPTION
add additional (and optional) parameter to use a key other than :uri
for the path. This is primarily to support immutant, which uses
:path-info but can be used to support any arbitrary key in the
request that other servers might use.

Thank you for your consideration.  
