### PR TITLE
mime-type: manifest => text/cache-manifest

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -4,6 +4,7 @@
 (def default-mime-types
   {"7z"    "application/x-7z-compressed"
    "aac"   "audio/aac"
+   "manifest" "text/cache-manifest"
    "ai"    "application/postscript"
    "asc"   "text/plain"
    "atom"  "application/atom+xml"


### PR DESCRIPTION
http://www.w3.org/TR/offline-webapps/
`wrap-file-info` is quite extensible, but adding this quite handy.
