### PR TITLE
Corrected date comparison between If-Modified-Since and Last-Modified header values.

### DIFF
--- a/ring-core/src/ring/middleware/not_modified.clj
+++ b/ring-core/src/ring/middleware/not_modified.clj
@@ -13,11 +13,11 @@
     (parse-date http-date)))
 
 (defn- not-modified-since? [request response]
-  (let [modified-date  (date-header response "last-modified")
+  (let [modified-date  (date-header response "Last-Modified")
         modified-since (date-header request "if-modified-since")]
     (and modified-date
          modified-since
-         (.before modified-since modified-date))))
+         (not (.before modified-since modified-date)))))
 
 (defn not-modified-response
   "Returns 304 or original response based on response and request."


### PR DESCRIPTION
Date comparison condition is inverted.
In particular equal dates now produce 304 response.
Updated tests.

Note that there are other problems with wrap-not-modified: see branch https://github.com/PetrGlad/ring/commit/get-header for temporary fix for remaining problem  
