### PR TITLE
Bump codox dependency to 0.6.4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -10,7 +10,7 @@
      [ring/ring-servlet "1.2.0-beta1"]]
   :plugins
     [[lein-sub "0.2.1"]
-     [codox "0.6.3"]]
+     [codox "0.6.4"]]
   :sub
     ["ring-core"
      "ring-devel"


### PR DESCRIPTION
On `codox 0.6.3` and Leiningen 2.0.0 running `lein doc` returns a `Exception in thread "main" java.lang.AssertionError: Assert failed: (vector? (:dependencies project []))` error, that's fixed, as far as I understood, in `codox 0.6.4`. 
