### PR TITLE
Added mime-type for hbs (handlebars) file format

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -31,6 +31,7 @@
    "flac"  "audio/flac"
    "gif"   "image/gif"
    "gz"    "application/gzip"
+   "hbs"   "text/x-handlebars"
    "htm"   "text/html"
    "html"  "text/html"
    "ico"   "image/x-icon"


### PR DESCRIPTION
Figured this might be useful to some folks using Ember.js and similar javascript frameworks.
