### PR TITLE
Fix ext-mime-type for non-lowercase extensions

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -90,7 +90,8 @@
 (defn- filename-ext
   "Returns the file extension of a filename or filepath."
   [filename]
-  (second (re-find #"\.([^./\\]+)$" filename)))
+  (when-let [ext (second (re-find #"\.([^./\\]+)$" filename))]            |
+    (.toLowerCase ^String ext)))
 
 (defn ext-mime-type
   "Get the mimetype from the filename extension. Takes an optional map of


### PR DESCRIPTION
Currently ext-mime-type doesn't recognise file extensions in upper case, which can be a problem for user-generated content.
