### PR TITLE
Update WOFF mime type

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -79,7 +79,7 @@
    "txt"   "text/plain"
    "webm"  "video/webm"
    "wmv"   "video/x-ms-wmv"
-   "woff"  "application/x-font-woff"
+   "woff"  "application/font-woff"
    "xbm"   "image/x-xbitmap"
    "xls"   "application/vnd.ms-excel"
    "xml"   "text/xml"


### PR DESCRIPTION
W3C updated WOFF from draft to recommendation status. Thus the x- prefix is now obsolete.
