### PR TITLE
Allow flash to be cleared after requests again

### DIFF
--- a/ring-core/src/ring/middleware/flash.clj
+++ b/ring-core/src/ring/middleware/flash.clj
@@ -31,4 +31,4 @@
     (when-let [resp (-> request
                         flash-request
                         handler)]
-      (flash-response resp request))))
+      (flash-response resp (flash-request request)))))

--- a/ring-core/test/ring/middleware/test/flash.clj
+++ b/ring-core/test/ring/middleware/test/flash.clj
@@ -23,6 +23,13 @@
     (is (nil? (:flash response)))
     (is (= (:session response) {:foo "bar"}))))
 
+(deftest flash-is-removed-after-read-not-touching-session-explicitly
+  (let [message  {:error "Could not save"}
+        handler  (wrap-flash (constantly {:status 200}))
+        response (handler {:session {:_flash message :foo "bar"}})]
+    (is (nil? (:flash response)))
+    (is (= (:session response) {:foo "bar"}))))
+
 (deftest flash-doesnt-wipe-session
   (let [message  {:error "Could not save"}
         handler  (wrap-flash (constantly {:flash message}))


### PR DESCRIPTION
Looks like the change in bbd5dfa8c53fcb65257610f6cb72360dfcf5d3a2 prevented this from
happening. It appears to have been the original rebinding of the same name (`session`) that caused confusion when the request/response flash handlers got split out.
