### PR TITLE
Add a way to get a Jetty Server instance without starting it

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -65,7 +65,6 @@
   :configurator - a function called with the Jetty Server instance
   :port         - the port to listen on (defaults to 80)
   :host         - the hostname to listen on
-  :start?       - starts the server (defaults to true)
   :join?        - blocks the thread until server ends (defaults to true)
   :daemon?      - use daemon threads (defaults to false)
   :ssl?         - allow connections over HTTPS
@@ -87,8 +86,7 @@
       (.setThreadPool p))
     (when-let [configurator (:configurator options)]
       (configurator s))
-    (when (:start? options true)
-      (.start s))
+    (.start s)
     (when (:join? options true)
       (.join s))
     s))

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -20,6 +20,12 @@
           (servlet/update-servlet-response response response-map)
           (.setHandled base-request true))))))
 
+(defn add-handler
+  "Adds a Ring handler to the provided Jetty Server instance."
+  [server handler]
+  (.setHandler server (proxy-handler handler))
+  server)
+
 (defn- ssl-context-factory
   "Creates a new SslContextFactory instance from a map of options."
   [options]
@@ -81,9 +87,8 @@
         ^QueuedThreadPool p (QueuedThreadPool. ^Integer (options :max-threads 50))]
     (when (:daemon? options false)
       (.setDaemon p true))
-    (doto s
-      (.setHandler (proxy-handler handler))
-      (.setThreadPool p))
+    (add-handler s handler)
+    (.setThreadPool s p)
     (when-let [configurator (:configurator options)]
       (configurator s))
     (.start s)

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -65,6 +65,7 @@
   :configurator - a function called with the Jetty Server instance
   :port         - the port to listen on (defaults to 80)
   :host         - the hostname to listen on
+  :start?       - starts the server (defaults to true)
   :join?        - blocks the thread until server ends (defaults to true)
   :daemon?      - use daemon threads (defaults to false)
   :ssl?         - allow connections over HTTPS
@@ -86,7 +87,8 @@
       (.setThreadPool p))
     (when-let [configurator (:configurator options)]
       (configurator s))
-    (.start s)
+    (when (:start? options true)
+      (.start s))
     (when (:join? options true)
       (.join s))
     s))

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -104,9 +104,4 @@
           (is (= (:scheme request-map) :http))
           (is (= (:server-name request-map) "localhost"))
           (is (= (:server-port request-map) 4347))
-          (is (= (:ssl-client-cert request-map) nil))))))
-
-  (testing "don't start"
-    (let [server (run-jetty hello-world {:port 4347 :join? false :start? false})]
-      (is (not (.isRunning server)))
-      (.stop server))))
+          (is (= (:ssl-client-cert request-map) nil)))))))

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -104,4 +104,9 @@
           (is (= (:scheme request-map) :http))
           (is (= (:server-name request-map) "localhost"))
           (is (= (:server-port request-map) 4347))
-          (is (= (:ssl-client-cert request-map) nil)))))))
+          (is (= (:ssl-client-cert request-map) nil))))))
+
+  (testing "don't start"
+    (let [server (run-jetty hello-world {:port 4347 :join? false :start? false})]
+      (is (not (.isRunning server)))
+      (.stop server))))


### PR DESCRIPTION
À la [creating an instance of your application without starting it](http://thinkrelevance.com/blog/2013/06/04/clojure-workflow-reloaded), I'd like to be able to call `run-jetty` to get an _instance_ of the server, but without the side effect of actually starting it.
