### PR TITLE
Jetty maxIdleTime setting

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -43,14 +43,16 @@
   [options]
   (doto (SslSelectChannelConnector. (ssl-context-factory options))
     (.setPort (options :ssl-port 443))
-    (.setHost (options :host))))
+    (.setHost (options :host))
+    (.setMaxIdleTime (options :max-idle-time 200000))))
 
 (defn- create-server
   "Construct a Jetty Server instance."
   [options]
   (let [connector (doto (SelectChannelConnector.)
                     (.setPort (options :port 80))
-                    (.setHost (options :host)))
+                    (.setHost (options :host))
+                    (.setMaxIdleTime (options :max-idle-time 200000)))
         server    (doto (Server.)
                     (.addConnector connector)
                     (.setSendDateHeader true))]
@@ -74,6 +76,7 @@
   :truststore   - a truststore to use for SSL connections
   :trust-password - the password to the truststore
   :max-threads  - the maximum number of threads to use (default 50)
+  :max-idle-time  - the maximum idle time in milliseconds for a connection (default 200000)
   :client-auth  - SSL client certificate authenticate, may be set to :need,
                   :want or :none (defaults to :none)"
   [handler options]

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -75,6 +75,29 @@
         (is (not (.. server getThreadPool isDaemon)))
         (.stop server))))
 
+  (testing "setting max idle timeout"
+    (let [server (run-jetty hello-world {:port 4347
+                                         :ssl-port 4348
+                                         :keystore "test/keystore.jks"
+                                         :key-password "password"
+                                         :join? false
+                                         :max-idle-time 5000})
+          connectors (. server getConnectors)]
+      (is (= 5000 (. (first connectors) getMaxIdleTime)))
+      (is (= 5000 (. (second connectors) getMaxIdleTime)))
+      (.stop server)))
+
+  (testing "using the default max idle time"
+    (let [server (run-jetty hello-world {:port 4347
+                                         :ssl-port 4348
+                                         :keystore "test/keystore.jks"
+                                         :key-password "password"
+                                         :join? false})
+          connectors (. server getConnectors)]
+      (is (= 200000 (. (first connectors) getMaxIdleTime)))
+      (is (= 200000 (. (second connectors) getMaxIdleTime)))
+      (.stop server)))
+
   (testing "default character encoding"
     (with-server (content-type-handler "text/plain") {:port 4347}
       (let [response (http/get "http://localhost:4347")]


### PR DESCRIPTION
The Jetty default for the max idle time is rather high in some uses cases and isn't ideal. 
I've added the option to explicitly set the max idle time for Jetty. 
