### PR TITLE
Minimum number of thread Jetty starts with

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -76,12 +76,14 @@
   :truststore   - a truststore to use for SSL connections
   :trust-password - the password to the truststore
   :max-threads  - the maximum number of threads to use (default 50)
+  :min-threads  - the minimum number of threads to use (default 8)
   :max-idle-time  - the maximum idle time in milliseconds for a connection (default 200000)
   :client-auth  - SSL client certificate authenticate, may be set to :need,
                   :want or :none (defaults to :none)"
   [handler options]
   (let [^Server s (create-server (dissoc options :configurator))
         ^QueuedThreadPool p (QueuedThreadPool. ^Integer (options :max-threads 50))]
+    (.setMinThreads p (options :min-threads 8))
     (when (:daemon? options false)
       (.setDaemon p true))
     (doto s

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -98,6 +98,21 @@
       (is (= 200000 (. (second connectors) getMaxIdleTime)))
       (.stop server)))
 
+  (testing "setting min-threads"
+    (let [server (run-jetty hello-world {:port 4347
+                                         :min-threads 3
+                                         :join? false})
+          thread-pool (. server getThreadPool)]
+      (is (= 3 (. thread-pool getMinThreads)))
+      (.stop server)))
+
+  (testing "default min-threads"
+    (let [server (run-jetty hello-world {:port 4347
+                                         :join? false})
+          thread-pool (. server getThreadPool)]
+      (is (= 8 (. thread-pool getMinThreads)))
+      (.stop server)))
+
   (testing "default character encoding"
     (with-server (content-type-handler "text/plain") {:port 4347}
       (let [response (http/get "http://localhost:4347")]


### PR DESCRIPTION
I added the ability to specify the number of minimum number of threads. This is especially useful for apps that have a heavy constant load and want to avoid the churn of Jetty slowly scaling up the threads to the max. 
