### PR TITLE
make ring.middleware.stacktrace manage assert exceptions, fixes ring-clojure/ring#79

### DIFF
--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -15,7 +15,7 @@
   (fn [request]
     (try
       (handler request)
-      (catch Exception ex
+      (catch Throwable ex
         (pst-on *err* color? ex)
         (throw ex)))))
 
@@ -78,7 +78,7 @@
   (fn [request]
     (try
       (handler request)
-      (catch Exception ex
+      (catch Throwable ex
         (ex-response request ex)))))
 
 (defn wrap-stacktrace


### PR DESCRIPTION
`ring.middleware.stacktrace` currently can't manage `AssertErrors`, the problem was reported on ring-clojure/ring#79 . This patch fixes it. 
