### PR TITLE
Make javax.servlet 2.5 a provided dependency 

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -8,8 +8,9 @@
                  [ring/ring-codec "1.0.0"]
                  [commons-io "2.4"]
                  [commons-fileupload "1.3"]
-                 [javax.servlet/servlet-api "2.5"]
                  [clj-time "0.4.4"]]
   :profiles
-  {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
+  {:provided {:dependencies [[javax.servlet/servlet-api "2.5"]]}
+   :dev {:dependencies [[javax.servlet/servlet-api "2.5"]]}
+   :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
    :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}})

--- a/ring-servlet/project.clj
+++ b/ring-servlet/project.clj
@@ -3,8 +3,9 @@
   :url "https://github.com/ring-clojure/ring"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[ring/ring-core "1.2.0"]
-                 [javax.servlet/servlet-api "2.5"]]
+  :dependencies [[ring/ring-core "1.2.0"]]
   :profiles
-  {:1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
+  {:provided {:dependencies [[javax.servlet/servlet-api "2.5"]]}
+   :dev {:dependencies [[javax.servlet/servlet-api "2.5"]]}
+   :1.4 {:dependencies [[org.clojure/clojure "1.4.0"]]}
    :1.5 {:dependencies [[org.clojure/clojure "1.5.1"]]}})


### PR DESCRIPTION
When running in a servlet 3.0 environment (jetty 8+) we run into the following security exception as the signer for javax.servlet 2.5 and javax.servlet 3.0 differ (at least in the case of Jetty):

```
Exception in thread "main" java.lang.SecurityException: class "javax.servlet.AsyncContext"'s signer information   does not match signer information of other classes in the same package
```

By making the dependency provided we use the underlying container's or adapter's version, which is what we want (of course as long javax.servlet remains backwards compatible with 2.5)
