### PR TITLE
[middleware/nested_params] Avoid keys that don't have a nested syntax

### DIFF
--- a/ring-core/test/ring/middleware/test/nested_params.clj
+++ b/ring-core/test/ring/middleware/test/nested_params.clj
@@ -3,6 +3,15 @@
   (:use clojure.test
         ring.middleware.nested-params))
 
+(deftest merge-with-union-test
+  (testing ":merging different data structures"
+    (are [p r q] (= (#'ring.middleware.nested-params/merge-with-union p r) q)
+      []          []                []
+      [:a]        [:b]              [:a :b]
+      []          :b                [:b]
+      {:x [:b]}   {:x [:b {:y :c}]} {:x [:b {:y :c}]}
+      {:foo :bar} {:foo :baz}       {:foo [:bar :baz]})))
+
 (deftest nested-params-test
   (let [handler (wrap-nested-params :params)]
     (testing "nested parameter maps"
@@ -35,6 +44,7 @@
                                     {:key-parser #(string/split % #"\.")})]
     (testing ":key-parser option"
       (are [p r] (= (handler {:params p}) r)
+           {"foo" {"bar" "baz"}} {"foo" {"bar" "baz"}}
            {"foo" ["bar" "baz"]} {"foo" ["bar" "baz"]}))))
 
 (deftest nested-params-request-test


### PR DESCRIPTION
First very simple attempt to address issue #22 && #85

Avoids trying to process keys that don't hint at being a nested-array (. or []).

With issue #22 being a year old I'm assuming no patch was ever submitted.
