### PR TITLE
Allow wrap-file to accept either String or File instances

### DIFF
--- a/ring-core/src/ring/middleware/file.clj
+++ b/ring-core/src/ring/middleware/file.clj
@@ -9,7 +9,7 @@
 (defn- ensure-dir
   "Ensures that a directory exists at the given path, throwing if one does not."
   [dir-path]
-  (let [dir (io/file dir-path)]
+  (let [dir (io/as-file dir-path)]
     (if-not (.exists dir)
       (throw (Exception. (format "Directory does not exist: %s" dir-path))))))
 

--- a/ring-core/test/ring/middleware/test/file.clj
+++ b/ring-core/test/ring/middleware/test/file.clj
@@ -57,3 +57,14 @@
     (is (= 200 status))
     (is (= (into #{} (keys headers)) #{"Content-Length" "Last-Modified"}))
     (is (nil? body))))
+
+(deftest test-wrap-file-with-java-io-file
+  (let [app (wrap-file (constantly :response) (File. public-dir))]
+    (let [{:keys [status headers body]} (app {:request-method :get :uri "/"})]
+      (is (= 200 status))
+      (is (= (into #{} (keys headers)) #{"Content-Length" "Last-Modified"}))
+      (is (= index-html body)))
+    (let [{:keys [status headers body]} (app {:request-method :get :uri "/foo.html"})]
+      (is (= 200 status))
+      (is (= (into #{} (keys headers)) #{"Content-Length" "Last-Modified"}))
+      (is (= foo-html body)))))


### PR DESCRIPTION
I've often found myself surprised by an error when I try to pass a File instance to wrap-file. Apologies if I'm missing an edge case that requires a String.