### PR TITLE
Adding DART mime type mapping

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -19,6 +19,7 @@
    "css"   "text/css"
    "csv"   "text/csv"
    "deb"   "application/x-deb"
+   "dart"  "application/dart"
    "dll"   "application/octet-stream"
    "dmg"   "application/octet-stream"
    "dms"   "application/octet-stream"


### PR DESCRIPTION
Chromium has a fork called [Dartium](https://www.dartlang.org/tools/dartium/) that has supports Dart natively without compiling to JS. 
