### PR TITLE
move transformation of HttpServletRequest -> request-map into middleware

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -13,11 +13,10 @@
   "Returns an Jetty Handler implementation for the given Ring handler."
   [handler]
   (proxy [AbstractHandler] []
-    (handle [_ ^Request base-request request response]
-      (let [request-map  (servlet/build-request-map request)
-            response-map (handler request-map)]
-        (when response-map
-          (servlet/update-servlet-response response response-map)
+    (handle [_ ^Request base-request servlet-request servlet-response]
+      (let [handler (servlet/wrap-servlet-request handler)]
+        (when-let [response-map (handler servlet-request)]
+          (servlet/update-servlet-response servlet-response response-map)
           (.setHandled base-request true))))))
 
 (defn- ssl-context-factory

--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -136,6 +136,22 @@
       ((make-service-method handler)
          this request response))))
 
+(defn wrap-servlet-request
+  "Transforms a handler that takes a standard ring request-map and returns a standard ring
+  response-map into a handler that expects an HttpServletRequest instead.
+
+  Handlers are wrapped using this by default, but there are cases where middleware needs the
+  underlying HttpServletRequest. In this case, simply add {:servlet-request true} to your handler's
+  metadata to prevent double wrapping."
+  [handler]
+  (if (:servlet-request (meta handler))
+    handler
+    (with-meta
+      (fn [^HttpServletRequest servlet-request]
+        (let [request (build-request-map servlet-request)]
+          (handler request)))
+      {:servlet-request true})))
+
 (defmacro defservice
   "Defines a service method with an optional prefix suitable for being used by
   genclass to compile a HttpServlet class.


### PR DESCRIPTION
This allows people to write middlewares, like the one for implementing Servlet 3.0 Asynchronous responses below, that use the HttpServletRequest directly.

This functionality is used by https://github.com/ninjudd/ring-async to provide streaming responses without consuming a thread.

@weavejester, what are your thoughts? Another approach would be to just leave the `:servlet-request` in the request-map, but it seems that's how ring used to work, and a decision was made to move away from that.
