### PR TITLE
Enumerate collection response `:body`s via `reduce`.

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -105,16 +105,18 @@ A response map is a Clojure map containing at least the following keys and corre
   sent for each such String value.
 
 :body
-  (Optional, {String, ISeq, File, InputStream})
-  A representation of the response body, if a response body is appropriate for 
-  the response's status code. The respond body is handled according to its type:
+  (Optional, {String, File, InputStream, ISeq, CollReduce})
+  A representation of the response body, if a response body is appropriate for
+  the response's status code. The response body is handled according to its type
+  or satisfying protocol:
   String:
     Contents are sent to the client as-is.
-  ISeq:
-    Each element of the seq is sent to the client as a string.
   File:
     Contents at the specified location are sent to the client. The server may 
     use an optimized method to send the file if such a method is available.
   InputStream:
     Contents are consumed from the stream and sent to the client. When the
     stream is exhausted, it is .close'd.
+  ISeq or CollReduce (>=1.4, satisfies protocol):
+    The body is `reduce`d and each element produced is sent to the client as a
+    string.

--- a/ring-servlet/test/ring/util/test/servlet.clj
+++ b/ring-servlet/test/ring/util/test/servlet.clj
@@ -1,6 +1,7 @@
 (ns ring.util.test.servlet
   (:use clojure.test
-        ring.util.servlet))
+        ring.util.servlet)
+  (:import [java.io PrintWriter StringWriter]))
 
 (defn- enumeration [coll]
   (let [e (atom coll)]
@@ -28,6 +29,11 @@
       (getAttribute [k] (attributes k))
       (getInputStream [] (request :body)))))
 
+(defn- maybe-assoc-body [m]
+  (if (contains? m :body)
+    m
+    (assoc m :body (StringWriter.))))
+
 (defn- servlet-response [response]
   (proxy [javax.servlet.http.HttpServletResponse] []
     (setStatus [status]
@@ -36,64 +42,84 @@
       (swap! response assoc-in [:headers name] value))
     (setCharacterEncoding [value])
     (setContentType [value]
-      (swap! response assoc :content-type value))))
+      (swap! response assoc :content-type value))
+    (getWriter []
+      (-> response (swap! maybe-assoc-body) :body PrintWriter.))))
 
 (defn- servlet-config []
   (proxy [javax.servlet.ServletConfig] []
     (getServletContext [] nil)))
 
-(defn- run-servlet [handler request response]
-  (doto (servlet handler)
-          (.init (servlet-config))
-          (.service (servlet-request request)
-                    (servlet-response response))))
+(defn- run-servlet [handler request]
+  (let [response (atom {})]
+    (doto (servlet handler)
+      (.init (servlet-config))
+      (.service (servlet-request request)
+                (servlet-response response)))
+    @response))
 
-(deftest servlet-test
+(def ^:private request
   (let [body (proxy [javax.servlet.ServletInputStream] [])
-        cert (proxy [java.security.cert.X509Certificate] [])
-        request {:server-port    8080
-                 :server-name    "foobar"
-                 :remote-addr    "127.0.0.1"
-                 :uri            "/foo"
-                 :query-string   "a=b"
-                 :scheme         :http
-                 :request-method :get
-                 :headers        {"X-Client" ["Foo", "Bar"]
-                                  "X-Server" ["Baz"]}
-                 :content-type   "text/plain"
-                 :content-length 10
-                 :character-encoding "UTF-8"
-                 :servlet-context-path "/foo"
-                 :ssl-client-cert cert
-                 :body            body}
-          response (atom {})]
-    (testing "request"
-      (letfn [(handler [r]
-               (are [k v] (= (r k) v)
-                 :server-port    8080
-                 :server-name    "foobar"
-                 :remote-addr    "127.0.0.1"
-                 :uri            "/foo"
-                 :query-string   "a=b"
-                 :scheme         :http
-                 :request-method :get
-                 :headers        {"x-client" "Foo,Bar"
-                                  "x-server" "Baz"}
-                 :content-type   "text/plain"
-                 :content-length 10
-                 :character-encoding "UTF-8"
-                 :servlet-context-path "/foo"
-                 :ssl-client-cert cert
-                 :body            body)
-               {:status 200, :headers {}})]
-        (run-servlet handler request response)))
-    (testing "response"
-      (letfn [(handler [r]
-               {:status  200
-                :headers {"Content-Type" "text/plain"
-                          "X-Server" "Bar"}
-                :body    nil})]
-        (run-servlet handler request response)
-        (is (= (@response :status) 200))
-        (is (= (@response :content-type) "text/plain"))
-        (is (= (get-in @response [:headers "X-Server"]) "Bar"))))))
+        cert (proxy [java.security.cert.X509Certificate] [])]
+    {:server-port    8080
+     :server-name    "foobar"
+     :remote-addr    "127.0.0.1"
+     :uri            "/foo"
+     :query-string   "a=b"
+     :scheme         :http
+     :request-method :get
+     :headers        {"X-Client" ["Foo", "Bar"]
+                      "X-Server" ["Baz"]}
+     :content-type   "text/plain"
+     :content-length 10
+     :character-encoding "UTF-8"
+     :servlet-context-path "/foo"
+     :ssl-client-cert cert
+     :body            body}))
+
+(deftest request-test
+  (testing "request"
+    (let [handler (fn [r]
+                    (are [k v] (= (r k) v)
+                         :server-port    8080
+                         :server-name    "foobar"
+                         :remote-addr    "127.0.0.1"
+                         :uri            "/foo"
+                         :query-string   "a=b"
+                         :scheme         :http
+                         :request-method :get
+                         :headers        {"x-client" "Foo,Bar"
+                                          "x-server" "Baz"}
+                         :content-type   "text/plain"
+                         :content-length 10
+                         :character-encoding "UTF-8"
+                         :servlet-context-path "/foo"
+                         :ssl-client-cert (:ssl-client-cert request)
+                         :body            (:body request))
+                    {:status 200, :headers {}})]
+      (run-servlet handler request))))
+
+(deftest response-test
+  (testing "response"
+    (let [handler (fn [r]
+                    {:status  200
+                     :headers {"Content-Type" "text/plain"
+                               "X-Server" "Bar"}
+                     :body    nil})
+          response (run-servlet handler request)]
+      (is (= (response :status) 200))
+      (is (= (response :content-type) "text/plain"))
+      (is (= (get-in response [:headers "X-Server"]) "Bar")))))
+
+(deftest response-body-test
+  (letfn [(mk-handler [body]
+            (fn [r]
+              {:status 200,
+               :headers {"Content-Type" "text/plain"},
+               :body body}))
+          (run-body [body]
+            (-> body mk-handler (run-servlet request) :body str))]
+    (is (= (run-body "success") "success") "String body")
+    (is (= (run-body (seq ["suc" "cess"])) "success") "ISeq body")
+    (if (reducible? [])
+      (is (= (run-body ["suc" "cess"]) "success") "CollReduce body"))))


### PR DESCRIPTION
In Clojure 1.5+, the `CollReduce` protocol provides a more flexible definition of a "collection" than `ISeq`.  In particular in the context of generating streaming chunked-encoded HTTP responses, `CollReduce` implementations may have lexically-scoped `finally`-style resource clean-up code.

Modiying the ring servlet adapter to use `CollReduce` instead of `ISeq` when available, then process the body via `reduce` instead of `doseq` should provide these benefits in an entirely backwards-compatible fashion.

This PR somewhat orthogonally fixes what I believe to be a bug in the current support for `ISeq` bodies.  Apparently `PrintWriter` instances never throw exceptions after construction, so e.g. a client closing a connection before completely recieving a chunked-encoded response would leave the `doseq` continuing to iterate until it had exhausted the body seq.  The `.checkError` method acts a `.flush`, but also reports if an error has occurred, allowing the adapter to throw an exception.
