### PR TITLE
Allow namespace style keywords as param names

### DIFF
--- a/ring-core/src/ring/middleware/keyword_params.clj
+++ b/ring-core/src/ring/middleware/keyword_params.clj
@@ -2,7 +2,7 @@
   "Convert param keys to keywords.")
 
 (defn- keyword-syntax? [s]
-  (re-matches #"[A-Za-z*+!_?-][A-Za-z0-9*+!_?-]*" s))
+  (re-matches #"[A-Za-z*+!_?-][A-Za-z0-9*+!_?/-]*" s))
 
 (defn- keyify-params [target]
   (cond

--- a/ring-core/src/ring/middleware/keyword_params.clj
+++ b/ring-core/src/ring/middleware/keyword_params.clj
@@ -2,7 +2,7 @@
   "Convert param keys to keywords.")
 
 (defn- keyword-syntax? [s]
-  (re-matches #"[A-Za-z*+!_?-][A-Za-z0-9*+!_?/-]*" s))
+  (re-matches #"[A-Za-z*+!_?-]([A-Za-z0-9*+!_?.-]*/)?[A-Za-z0-9*+!_?-]*" s))
 
 (defn- keyify-params [target]
   (cond

--- a/ring-core/src/ring/middleware/keyword_params.clj
+++ b/ring-core/src/ring/middleware/keyword_params.clj
@@ -1,34 +1,43 @@
 (ns ring.middleware.keyword-params
   "Convert param keys to keywords.")
 
-(defn- keyword-syntax? [s]
-  (re-matches #"[A-Za-z*+!_?-]([A-Za-z0-9*+!_?.-]*/)?[A-Za-z0-9*+!_?-]*" s))
+(def ^:private keyword-re #"[A-Za-z*+!_?-][A-Za-z0-9*+!_?-]*")
+(def ^:private namespaced-keyword-re
+  (re-pattern (str "([A-Za-z*+!_?-][A-Za-z0-9*+!_?.-]*/)?" keyword-re)))
 
-(defn- keyify-params [target]
+(defn- keyword-syntax? [s allow-namespaces?]
+  (re-matches
+   (if allow-namespaces? namespaced-keyword-re keyword-re)
+   s))
+
+(defn- keyify-params [target allow-namespaces?]
   (cond
     (map? target)
       (into {}
         (for [[k v] target]
-          [(if (and (string? k) (keyword-syntax? k))
+          [(if (and (string? k) (keyword-syntax? k allow-namespaces?))
              (keyword k)
              k)
-           (keyify-params v)]))
+           (keyify-params v allow-namespaces?)]))
     (vector? target)
-      (vec (map keyify-params target))
+    (vec (map #(keyify-params % allow-namespaces?) target))
     :else
       target))
 
 (defn keyword-params-request
   "Converts string keys in :params map to keywords."
-  [req]
-  (update-in req [:params] keyify-params))
+  [req & [{:keys [allow-namespaces?]
+           :or {:allow-namespaces? false}}]]
+  (update-in req [:params] keyify-params allow-namespaces?))
 
 (defn wrap-keyword-params
   "Middleware that converts the string-keyed :params map to one with keyword
   keys before forwarding the request to the given handler.
-  Does not alter the maps under :*-params keys; these are left with strings."
-  [handler]
+  Does not alter the maps under :*-params keys; these are left with strings.
+  Takes an optional configuration map. Recognized keys are:
+    :allow-namespaces? - defaults to false"
+  [handler & [opts]]
   (fn [req]
     (-> req
-        keyword-params-request
+        (keyword-params-request opts)
         handler)))

--- a/ring-core/test/ring/middleware/test/keyword_params.clj
+++ b/ring-core/test/ring/middleware/test/keyword_params.clj
@@ -17,7 +17,9 @@
     {:foo "bar"}
     {:foo "bar"}
     {"foo" {:bar "baz"}}
-    {:foo {:bar "baz"}}))
+    {:foo {:bar "baz"}}
+    {"ns/foo" "bar"}
+    {:ns/foo "bar"}))
 
 (deftest keyword-params-request-test
   (is (fn? keyword-params-request)))

--- a/ring-core/test/ring/middleware/test/keyword_params.clj
+++ b/ring-core/test/ring/middleware/test/keyword_params.clj
@@ -3,25 +3,31 @@
         ring.middleware.keyword-params))
 
 (def wrapped-echo (wrap-keyword-params identity))
+(def wrapped-echo-with-ns (wrap-keyword-params identity {:allow-namespaces? true}))
 
 (deftest test-wrap-keyword-params
-  (are [in out] (= out (:params (wrapped-echo {:params in})))
-    {"foo" "bar" "biz" "bat"}
-    {:foo  "bar" :biz  "bat"}
-    {"foo" "bar" "biz" [{"bat" "one"} {"bat" "two"}]}
-    {:foo  "bar" :biz  [{:bat "one"}  {:bat  "two"}]}
-    {"foo" 1}
-    {:foo  1}
-    {"foo" 1 "1bar" 2 "baz*" 3 "quz-buz" 4 "biz.bang" 5}
-    {:foo 1 "1bar" 2 :baz* 3 :quz-buz 4 "biz.bang" 5}
-    {:foo "bar"}
-    {:foo "bar"}
-    {"foo" {:bar "baz"}}
-    {:foo {:bar "baz"}}
-    {"ns/foo" "bar" "ns/wtf/foo" "baz"}
-    {:ns/foo "bar" "ns/wtf/foo" "baz"}
-    {"dotted.ns/foo" "bar"}
-    {:dotted.ns/foo "bar"}))
+  (testing "default behavior"
+    (are [in out] (= out (:params (wrapped-echo {:params in})))
+         {"foo" "bar" "biz" "bat"}
+         {:foo  "bar" :biz  "bat"}
+         {"foo" "bar" "biz" [{"bat" "one"} {"bat" "two"}]}
+         {:foo  "bar" :biz  [{:bat "one"}  {:bat  "two"}]}
+         {"foo" 1}
+         {:foo  1}
+         {"foo" 1 "1bar" 2 "baz*" 3 "quz-buz" 4 "biz.bang" 5}
+         {:foo 1 "1bar" 2 :baz* 3 :quz-buz 4 "biz.bang" 5}
+         {:foo "bar"}
+         {:foo "bar"}
+         {"foo" {:bar "baz"}}
+         {:foo {:bar "baz"}}
+         {"ns/foo" "bar"}
+         {"ns/foo" "bar"}))
+  (testing "allow-namespaces? true"
+    (are [in out] (= out (:params (wrapped-echo-with-ns {:params in})))
+         {"ns/foo" "bar" "ns/wtf/foo" "baz" "foo/1" "fizz" "foo/bar1" "buzz"}
+         {:ns/foo "bar" "ns/wtf/foo" "baz" "foo/1" "fizz" :foo/bar1 "buzz"}
+         {"dotted.ns/foo" "bar" "dotted.ns/1" "baz" "dotted.ns/bar1" "buzz"}
+         {:dotted.ns/foo "bar" "dotted.ns/1" "baz" :dotted.ns/bar1 "buzz"})))
 
 (deftest keyword-params-request-test
   (is (fn? keyword-params-request)))

--- a/ring-core/test/ring/middleware/test/keyword_params.clj
+++ b/ring-core/test/ring/middleware/test/keyword_params.clj
@@ -18,8 +18,10 @@
     {:foo "bar"}
     {"foo" {:bar "baz"}}
     {:foo {:bar "baz"}}
-    {"ns/foo" "bar"}
-    {:ns/foo "bar"}))
+    {"ns/foo" "bar" "ns/wtf/foo" "baz"}
+    {:ns/foo "bar" "ns/wtf/foo" "baz"}
+    {"dotted.ns/foo" "bar"}
+    {:dotted.ns/foo "bar"}))
 
 (deftest keyword-params-request-test
   (is (fn? keyword-params-request)))


### PR DESCRIPTION
Currently params with names such as "namespace/param-name" are skipped because "/" is not allowed by keyword-syntax? function.
