### PR TITLE
ring.util.response.ok

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -44,6 +44,8 @@
    :headers {}
    :body    body})
 
+(def ok "Returns a 200 'ok' response." response)
+
 (defn status
   "Returns an updated Ring response with the given status."
   [resp status]

--- a/ring-core/test/ring/util/test/response.clj
+++ b/ring-core/test/ring/util/test/response.clj
@@ -29,6 +29,10 @@
   (is (= {:status 200 :headers {} :body "foobar"}
          (response "foobar"))))
 
+(deftest test-ok
+  (is (= {:status 200 :headers {} :body "foobar"}
+         (ok "foobar"))))
+
 (deftest test-status
   (is (= {:status 200 :body ""} (status {:status nil :body ""} 200))))
 


### PR DESCRIPTION
hi.

would love to see `ok` in Ring. Because:
- it's a real http status code name for 200
- shorter than `response`
- already commonly used elsewhere (like in [Spray](https://github.com/spray/spray/blob/master/spray-http/src/main/scala/spray/http/StatusCode.scala) & [Play](http://www.playframework.com/documentation/2.0.4/api/scala/play/api/mvc/Results.html))
- first thing I write into my Ring-based web apps

regards,

Tommi
