### PR TITLE
Flush response more eagerly to support Server-Sent Events

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -1,7 +1,6 @@
 (ns ring.util.servlet
   "Compatibility functions for turning a ring handler into a Java servlet."
-  (:require [clojure.java.io :as io]
-            [clojure.string :as string])
+  (:require [clojure.string :as string])
   (:import (java.io File InputStream FileInputStream)
            (javax.servlet.http HttpServlet
                                HttpServletRequest

--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -76,7 +76,23 @@
         (.addHeader response key val))))
   ; Some headers must be set through specific methods
   (when-let [content-type (get headers "Content-Type")]
-    (.setContentType response content-type)))
+    (.setContentType response content-type))
+  ;; added by me
+  (.flushBuffer response))
+
+(defn copy [in output]
+  (let [buffer (make-array Byte/TYPE 1024)]
+    (loop []
+      (let [av (.available in)]
+        (if (pos? av)
+          (let [size (.read in buffer 0 (min av (alength buffer)))]
+            (if (pos? size)
+              (do (.write output buffer 0 size)
+                  (.flush output)
+                  (recur))))
+          (let [b (.read in)] ;; block
+            (.write output b)
+            (recur)))))))
 
 (defn- set-body
   "Update a HttpServletResponse body with a String, ISeq, File or InputStream."
@@ -92,7 +108,7 @@
           (.flush writer)))
     (instance? InputStream body)
       (with-open [^InputStream b body]
-        (io/copy b (.getOutputStream response)))
+        (copy b (.getOutputStream response)))
     (instance? File body)
       (let [^File f body]
         (with-open [stream (FileInputStream. f)]

--- a/ring-servlet/test/ring/util/test/servlet.clj
+++ b/ring-servlet/test/ring/util/test/servlet.clj
@@ -35,7 +35,8 @@
       (swap! response assoc-in [:headers name] value))
     (setCharacterEncoding [value])
     (setContentType [value]
-      (swap! response assoc :content-type value))))
+      (swap! response assoc :content-type value))
+    (flushBuffer [])))
 
 (defn- servlet-config []
   (proxy [javax.servlet.ServletConfig] []


### PR DESCRIPTION
Server-Sent Events are a [web standard][standard]. They require the headers to be sent before the body is ready. Also, the response stream should be flushed eagerly, so that events may be sent as they are written to the stream.

This pull request includes a function to copy and flush eagerly, and also flushes the response after headers are sent. It required an addition of a proxy method to the HTTPServletResponse testing mock.

[standard]: http://www.w3.org/TR/eventsource/