### PR TITLE
Remove the ring-core dependency from ring-servlet

### DIFF
--- a/ring-servlet/project.clj
+++ b/ring-servlet/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[ring/ring-core "1.2.1"]]
+  :dependencies [[org.clojure/clojure "1.3.0"]]
   :profiles
   {:provided {:dependencies [[javax.servlet/servlet-api "2.5"]]}
    :dev {:dependencies [[javax.servlet/servlet-api "2.5"]]}


### PR DESCRIPTION
`ring-core` is not needed by `ring-servlet`.

It requires `javax.servlet/servlet-api` and clojure only, which I assume is kept in profiles instead for distribution licensing reasons?
