### PR TITLE
Support the full Clojure keyword syntax, especially namespaced keywords.

### DIFF
--- a/ring-core/src/ring/middleware/keyword_params.clj
+++ b/ring-core/src/ring/middleware/keyword_params.clj
@@ -2,7 +2,7 @@
   "Convert param keys to keywords.")
 
 (defn- keyword-syntax? [s]
-  (re-matches #"[A-Za-z*+!_?-][A-Za-z0-9*+!_?-]*" s))
+  (re-matches #"(?:[A-Za-z*+!_?-][\w*+!_?-]*\.)*?[A-Za-z*+!_?-][\w*+!_?-]*(?:/(?:[A-Za-z*+!_?-][\w*+!_?-]*)*)?" s))
 
 (defn- keyify-params [target]
   (cond

--- a/ring-core/test/ring/middleware/test/keyword_params.clj
+++ b/ring-core/test/ring/middleware/test/keyword_params.clj
@@ -13,11 +13,17 @@
     {"foo" 1}
     {:foo  1}
     {"foo" 1 "1bar" 2 "baz*" 3 "quz-buz" 4 "biz.bang" 5}
-    {:foo 1 "1bar" 2 :baz* 3 :quz-buz 4 "biz.bang" 5}
+    {:foo 1 "1bar" 2 :baz* 3 :quz-buz 4 :biz.bang 5}
     {:foo "bar"}
     {:foo "bar"}
     {"foo" {:bar "baz"}}
-    {:foo {:bar "baz"}}))
+    {:foo {:bar "baz"}}
+    {"foo/bar" "baz"}
+    {:foo/bar "baz"}
+    {"foo.bar/baz" "quux"}
+    {:foo.bar/baz "quux"}
+    {"foo/bar/baz" "quux"}
+    {"foo/bar/baz" "quux"}))
 
 (deftest keyword-params-request-test
   (is (fn? keyword-params-request)))


### PR DESCRIPTION
Update the matcher regex to support namespaces. Don't accept multiple slashes. Don't accept periods after the slash. Don't accept multiple consecutive periods.
