### PR TITLE
update clj-time to 0.6.0

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -8,7 +8,7 @@
                  [ring/ring-codec "1.0.0"]
                  [commons-io "2.4"]
                  [commons-fileupload "1.3"]
-                 [clj-time "0.4.4"]
+                 [clj-time "0.6.0"]
                  [crypto-random "1.1.0"]
                  [crypto-equality "0.1.0"]]
   :profiles


### PR DESCRIPTION
Ring-core is using very old version of `clj-time`. Many web libs depend on the newer version, but the ring-core version keeps popping up (for example with `lein ring uberwar`, which adds it's ring-deps on the fly as top-most dependencies) => `clj-time` version needs to be manually set in the end projects despite not needing it directly. 

Example: https://github.com/metosin/compojure-api-examples/blob/master/project.clj#L4
