### PR TITLE
Issue #139: Default session cookies to HTTP-only.

### DIFF
--- a/ring-core/src/ring/middleware/session.clj
+++ b/ring-core/src/ring/middleware/session.clj
@@ -8,7 +8,8 @@
   [options]
   {:store (options :store (mem/memory-store))
    :cookie-name (options :cookie-name "ring-session")
-   :cookie-attrs (merge {:path "/"}
+   :cookie-attrs (merge {:path "/"
+                         :http-only true}
                         (options :cookie-attrs)
                         (if-let [root (options :root)]
                           {:path root}))})


### PR DESCRIPTION
Add test to ensure default setting can be overridden.

Update one existing test that needs to know about the new HttpOnly flag.

Update other tests to assert only the relevant portion of the cookie. This
means they don't rely on...
- the existence of flags they don't care about
- the sort-order mechanics of the cookie encoding impl
