### PR TITLE
Prevent filename-ext from throwing NPE on empty (:uri request)

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -94,7 +94,7 @@
 (defn- filename-ext
   "Returns the file extension of a filename or filepath."
   [filename]
-  (if-let [ext (second (re-find #"\.([^./\\]+)$" filename))]
+  (if-let [ext (second (re-find #"\.([^./\\]+)$" (str filename)))]
     (str/lower-case ext)))
 
 (defn ext-mime-type


### PR DESCRIPTION
Wrapped filename argument in str fn call to return an empty string on nil thereby preventing unnecessary NPE. This make it possible to use in a chain of middleware without disrupting the normal flow.