### PR TITLE
Help make port to Jetty 9 easier.

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -2,14 +2,13 @@
   "A Ring adapter that uses the Jetty 7 embedded web server.
 
   Adapters are used to convert Ring handlers into running web servers."
-  (:import (org.eclipse.jetty.server Server Request)
+  (:require [ring.util.servlet :as servlet])
+  (:import (org.eclipse.jetty.server Request Server)
            (org.eclipse.jetty.server.handler AbstractHandler)
            (org.eclipse.jetty.server.nio SelectChannelConnector)
            (org.eclipse.jetty.server.ssl SslSelectChannelConnector)
-           (org.eclipse.jetty.util.thread QueuedThreadPool)
            (org.eclipse.jetty.util.ssl SslContextFactory)
-           (javax.servlet.http HttpServletRequest HttpServletResponse))
-  (:require [ring.util.servlet :as servlet]))
+           (org.eclipse.jetty.util.thread QueuedThreadPool)))
 
 (defn- proxy-handler
   "Returns an Jetty Handler implementation for the given Ring handler."
@@ -51,16 +50,30 @@
     (.setHost (options :host))
     (.setMaxIdleTime (options :max-idle-time 200000))))
 
+(defn- connector
+  "Creates a SelectChannelConnector instance."
+  [options]
+  (doto (SelectChannelConnector.)
+    (.setPort (options :port 80))
+    (.setHost (options :host))
+    (.setMaxIdleTime (options :max-idle-time 200000))))
+
 (defn- create-server
   "Construct a Jetty Server instance."
   [options]
-  (let [connector (doto (SelectChannelConnector.)
-                    (.setPort (options :port 80))
-                    (.setHost (options :host))
-                    (.setMaxIdleTime (options :max-idle-time 200000)))
-        server    (doto (Server.)
-                    (.addConnector connector)
-                    (.setSendDateHeader true))]
+  (let [^QueuedThreadPool p (QueuedThreadPool.)
+        ^Server server (Server.)]
+    (doto p
+      (.setMinThreads ^Integer (options :min-threads 8))
+      (.setMaxThreads ^Integer (options :max-threads 50)))
+    (when-let [max-queued (:max-queued options)]
+      (.setMaxQueued p max-queued))
+    (when (:daemon? options false)
+      (.setDaemon p true))
+    (doto server
+      (.setSendDateHeader true)
+      (.setThreadPool p)
+      (.addConnector (connector options)))
     (when (or (options :ssl?) (options :ssl-port))
       (.addConnector server (ssl-connector options)))
     server))
@@ -87,16 +100,9 @@
   :client-auth    - SSL client certificate authenticate, may be set to :need,
                     :want or :none (defaults to :none)"
   [handler options]
-  (let [^Server s (create-server (dissoc options :configurator))
-        ^QueuedThreadPool p (QueuedThreadPool. ^Integer (options :max-threads 50))]
-    (.setMinThreads p (options :min-threads 8))
-    (when-let [max-queued (:max-queued options)]
-      (.setMaxQueued p max-queued))
-    (when (:daemon? options false)
-      (.setDaemon p true))
+  (let [^Server s (create-server (dissoc options :configurator))]
     (doto s
-      (.setHandler (proxy-handler handler))
-      (.setThreadPool p))
+      (.setHandler (proxy-handler handler)))
     (when-let [configurator (:configurator options)]
       (configurator s))
     (.start s)


### PR DESCRIPTION
This doesn't solve a problem per-se. This just moves a few things around so that there are fewer changes required to port to Jetty 9. With these changes a port to Jetty 9 looks like https://github.com/tvaughan/ring-jetty9-adapter/commit/e510dda5279f779bc63c67bd7d142cbcc0280eae. (This is actually incomplete. I haven't figured out how to handle the real API breakage between 7 and 9, like http://git.eclipse.org/c/jetty/org.eclipse.jetty.project.git/commit/jetty-util/src/main/java/org/eclipse/jetty/util/thread/QueuedThreadPool.java?id=8e98148350f215e2ec58d0b936ab08ce22229d6a.) Thanks!
