### PR TITLE
cope with newlines in parameter names

### DIFF
--- a/ring-core/src/ring/middleware/nested_params.clj
+++ b/ring-core/src/ring/middleware/nested_params.clj
@@ -11,7 +11,7 @@
     \"foo[bar][][baz]\"
     => [\"foo\" \"bar\" \"\" \"baz\"]"
   [param-name]
-  (let [[_ k ks] (re-matches #"(.*?)((?:\[.*?\])*)" (name param-name))
+  (let [[_ k ks] (re-matches #"(?s)(.*?)((?:\[.*?\])*)" (name param-name))
         keys     (if ks (map second (re-seq #"\[(.*?)\]" ks)))]
     (cons k keys)))
 

--- a/ring-core/test/ring/middleware/test/nested_params.clj
+++ b/ring-core/test/ring/middleware/test/nested_params.clj
@@ -25,7 +25,10 @@
     (testing "duplicate parameters"
       (are [p r] (= (handler {:params p}) r)
         {"a" ["b" "c"]}    {"a" ["b" "c"]}
-        {"a[b]" ["c" "d"]} {"a" {"b" ["c" "d"]}}))))
+        {"a[b]" ["c" "d"]} {"a" {"b" ["c" "d"]}}))
+    (testing "parameters with newlines"
+      (are [p r] (= (handler {:params p}) r)
+        {"foo\nbar" "baz"} {"foo\nbar" "baz"}))))
 
 (deftest nested-params-test-with-options
   (let [handler (wrap-nested-params :params


### PR DESCRIPTION
The code in parse-nested-keys is assuming that (.*?) will always match
the entire param-name, but that assumption fails without the (?s) modifier,
if param-name happens to include a newline character.

The eventual fallout from this bug is that :params will no longer be a map
after it runs through wrap-nested-params, which causes mayhem downstream with
all the code that assumes :params is a map.

It's possible that the fix actually belongs elsewhere -- for example, it
might be "more correct" to 400 these requests: I don't know what the
standards have to say about newlines in form parameters. Even if this
isn't the _whole_ fix, though, IMO this change should be made on
"defense in depth" grounds.

FWIW: curl can produce requests with newline-containing form params,
like so:

``` bash
    $ cat > bad.form
    foo
    bar = baz
    ^D
    $ curl --data-binary @bad.form ...
```
