### PR TITLE
Update clj-time to 0.7.0

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -9,7 +9,7 @@
                  [ring/ring-codec "1.0.0"]
                  [commons-io "2.4"]
                  [commons-fileupload "1.3"]
-                 [clj-time "0.6.0"]
+                 [clj-time "0.7.0"]
                  [crypto-random "1.2.0"]
                  [crypto-equality "1.0.0"]]
   :profiles


### PR DESCRIPTION
I was getting `java.lang.IllegalAccessError: in-seconds does not exist, compiling:(ring/middleware/cookies.clj:1:1)`. 

Turns out `ring-core`'s dependencies still use `clj-time "0.6.0"` which had `in-secs`, but it's source code uses `0.7.0`'s `in-seconds`.
