### PR TITLE
handle multiple Cookie headers

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -28,8 +28,10 @@
 (defn- parse-cookie-header
   "Turn a HTTP Cookie header into a list of name/value pairs."
   [header]
-  (for [[_ name value] (re-seq re-cookie header)]
-    [name value]))
+  (let [headers (if (coll? header) header [header])]
+    (->> headers
+         (mapcat #(re-seq re-cookie %))
+         (map rest))))
 
 (defn- strip-quotes
   "Strip quotes from a cookie value."

--- a/ring-core/test/ring/middleware/test/cookies.clj
+++ b/ring-core/test/ring/middleware/test/cookies.clj
@@ -15,6 +15,12 @@
     (is (= {"a" {:value "b"}, "c" {:value "d"}, "e" {:value "f"}}
            resp))))
 
+(deftest wrap-cookies-multiple-cookie-headers
+  (let [req  {:headers {"cookie" ["a=b" "c=d,e=f"]}}
+        resp ((wrap-cookies :cookies) req)]
+    (is (= {"a" {:value "b"}, "c" {:value "d"}, "e" {:value "f"}}
+           resp))))
+
 (deftest wrap-cookies-quoted-cookies
   (let [req  {:headers {"cookie" "a=\"b\""}}
         resp ((wrap-cookies :cookies) req)]


### PR DESCRIPTION
Handles multiple Cookie headers in request.  When multiple Cookie headers are present, ring maps to them to a collection of string values rather than a string value.

We frequently see crawlers/bots (e.g. semantic-visions.com, tweetedtimes.com) that send multiple Cookie headers which currently result into thrown exceptions in ring and 500 responses.
