### PR TITLE
Revert "handle multiple Cookie headers"

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -28,10 +28,8 @@
 (defn- parse-cookie-header
   "Turn a HTTP Cookie header into a list of name/value pairs."
   [header]
-  (let [headers (if (coll? header) header [header])]
-    (->> headers
-         (mapcat #(re-seq re-cookie %))
-         (map rest))))
+  (for [[_ name value] (re-seq re-cookie header)]
+    [name value]))
 
 (defn- strip-quotes
   "Strip quotes from a cookie value."

--- a/ring-core/test/ring/middleware/test/cookies.clj
+++ b/ring-core/test/ring/middleware/test/cookies.clj
@@ -15,12 +15,6 @@
     (is (= {"a" {:value "b"}, "c" {:value "d"}, "e" {:value "f"}}
            resp))))
 
-(deftest wrap-cookies-multiple-cookie-headers
-  (let [req  {:headers {"cookie" ["a=b" "c=d,e=f"]}}
-        resp ((wrap-cookies :cookies) req)]
-    (is (= {"a" {:value "b"}, "c" {:value "d"}, "e" {:value "f"}}
-           resp))))
-
 (deftest wrap-cookies-quoted-cookies
   (let [req  {:headers {"cookie" "a=\"b\""}}
         resp ((wrap-cookies :cookies) req)]


### PR DESCRIPTION
Reverts ring-clojure/ring#153

The Ring SPEC doesn't allow request maps with headers that map strings to collections, so the bug that this PR fixes exists only because the request map coming in is malformed.
