### PR TITLE
Use (long x) instead of (Long. x) in content-length

### DIFF
--- a/ring-core/src/ring/util/request.clj
+++ b/ring-core/src/ring/util/request.clj
@@ -25,7 +25,7 @@
   {:added "1.3"}
   [request]
   (if-let [length (get-in request [:headers "content-length"])]
-    (Long. length)))
+    (long length)))
 
 (def ^:private charset-pattern
   (re-pattern (str ";(?:.*\\s)?(?i:charset)=(" re-value ")\\s*(?:;|$)")))


### PR DESCRIPTION
Pedestal Pedestal uses `Integer/parseInt` to create content-length for
multipart messages. Ring fails, because there is no 
constructor with Integer parameter.
