### PR TITLE
Fix form field encoding in multipart middleware

### DIFF
--- a/ring-core/src/ring/middleware/multipart_params.clj
+++ b/ring-core/src/ring/middleware/multipart_params.clj
@@ -48,10 +48,10 @@
 (defn- parse-file-item
   "Parse a FileItemStream into a key-value pair. If the request is a file the
   supplied store function is used to save it."
-  [^FileItemStream item store]
+  [^FileItemStream item store encoding]
   [(.getFieldName item)
    (if (.isFormField item)
-     (Streams/asString (.openStream item))
+     (Streams/asString (.openStream item) encoding)
      (store {:filename     (.getName item)
              :content-type (.getContentType item)
              :stream       (.openStream item)}))])
@@ -61,7 +61,7 @@
   [request encoding store]
   (->> (request-context request encoding)
        (file-item-seq)
-       (map #(parse-file-item % store))
+       (map #(parse-file-item % store encoding))
        (reduce (fn [m [k v]] (assoc-conj m k v)) {})))
 
 (defn- load-var

--- a/ring-core/test/ring/middleware/test/multipart_params.clj
+++ b/ring-core/test/ring/middleware/test/multipart_params.clj
@@ -79,3 +79,15 @@
 
 (deftest multipart-params-request-test
   (is (fn? multipart-params-request)))
+
+(deftest test-utf8-encoding-support
+  (let [form-body (str "--XXXX\r\n"
+                       "Content-Disposition: form-data;"
+                       "name=\"foo\"\r\n\r\n"
+                       "Øæßç®£èé\r\n"
+                       "--XXXX--")
+        request {:headers {"content-type"
+                           (str "multipart/form-data; boundary=XXXX")}
+                 :body (string-input-stream form-body "UTF-8")}
+        request* (multipart-params-request request)]
+        (is (= (get-in request* [:multipart-params "foo"]) "Øæßç®£èé"))))


### PR DESCRIPTION
multipart/formdata requests are supported in ring, but there's an issue when you have form fields in e.g. UTF-8 encoding. The form fields are currently not parsed correctly with respect to their encoding. The following example currently fails with ring, but will succeed with this patch.

```
<form method="post" enctype="multipart/form-data" acceptcharset="UTF-8">
   <input type="text" name="param-name" value="èéèéè" />
  <button type="submit" >Submit</button>
</form>
```
