### PR TITLE
When parameters are already nested, don't re-nest

### DIFF
--- a/ring-core/src/ring/middleware/nested_params.clj
+++ b/ring-core/src/ring/middleware/nested_params.clj
@@ -37,7 +37,7 @@
   [params]
   (mapcat
     (fn [[name value]]
-      (if (sequential? value)
+      (if (and (sequential? value) (not (coll? (first value))))
         (for [v value] [name v])
         [[name value]]))
     params))

--- a/ring-core/test/ring/middleware/test/nested_params.clj
+++ b/ring-core/test/ring/middleware/test/nested_params.clj
@@ -28,7 +28,19 @@
         {"a[b]" ["c" "d"]} {"a" {"b" ["c" "d"]}}))
     (testing "parameters with newlines"
       (are [p r] (= (handler {:params p}) r)
-        {"foo\nbar" "baz"} {"foo\nbar" "baz"}))))
+        {"foo\nbar" "baz"} {"foo\nbar" "baz"}))
+    (testing "parameters are already nested"
+      (is (= {"foo" [["bar" "baz"] ["asdf" "zxcv"]]}
+             (handler {:params {"foo" [["bar" "baz"] ["asdf" "zxcv"]]}}))))
+    (testing "pre-nested vector of maps"
+      (is (= {"foo" [{"bar" "baz"} {"asdf" "zxcv"}]}
+             (handler {:params {"foo" [{"bar" "baz"} {"asdf" "zxcv"}]}}))))
+    (testing "pre-nested map"
+      (is (= {"foo" [{"bar" "baz" "asdf" "zxcv"}]}
+             (handler {:params {"foo" [{"bar" "baz" "asdf" "zxcv"}]}}))))
+    (testing "double-nested map"
+      (is (= {"foo" {"key" {"bar" "baz" "asdf" "zxcv"}}}
+             (handler {:params {"foo" {"key" {"bar" "baz" "asdf" "zxcv"}}}}))))))
 
 (deftest nested-params-test-with-options
   (let [handler (wrap-nested-params :params


### PR DESCRIPTION
The param map can have nested contents if something like wrap-json-params runs before wrap-nested-params. This causes odd behavior.

This commit changes param-pairs so that already-nested values are not re-nested in weird ways.
