### PR TITLE
Add protocol to request.

### DIFF
--- a/SPEC
+++ b/SPEC
@@ -65,6 +65,10 @@ corresponding values:
   The HTTP request method, must be a lowercase keyword corresponding to a HTTP
   request method, such as :get or :post.
 
+:protocol
+  (Required, String)
+  The HTTP protocol version the request was made with.
+
 :content-type [DEPRECATED]
   (Optional, String)
   The MIME type of the request body, if known.

--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -41,6 +41,7 @@
    :query-string       (.getQueryString request)
    :scheme             (keyword (.getScheme request))
    :request-method     (keyword (.toLowerCase (.getMethod request)))
+   :protocol           (.getProtocol request)
    :headers            (get-headers request)
    :content-type       (.getContentType request)
    :content-length     (get-content-length request)

--- a/ring-servlet/test/ring/util/test/servlet.clj
+++ b/ring-servlet/test/ring/util/test/servlet.clj
@@ -20,6 +20,7 @@
       (getContextPath [] (request :servlet-context-path))
       (getScheme [] (name (request :scheme)))
       (getMethod [] (-> request :request-method name .toUpperCase))
+      (getProtocol [] (request :protocol))
       (getHeaderNames [] (enumeration (keys (request :headers))))
       (getHeaders [name] (enumeration (get-in request [:headers name])))
       (getContentType [] (request :content-type))
@@ -58,6 +59,7 @@
                  :query-string   "a=b"
                  :scheme         :http
                  :request-method :get
+                 :protocol       "HTTP/1.1"
                  :headers        {"X-Client" ["Foo", "Bar"]
                                   "X-Server" ["Baz"]}
                  :content-type   "text/plain"
@@ -77,6 +79,7 @@
                  :query-string   "a=b"
                  :scheme         :http
                  :request-method :get
+                 :protocol       "HTTP/1.1"
                  :headers        {"x-client" "Foo,Bar"
                                   "x-server" "Baz"}
                  :content-type   "text/plain"


### PR DESCRIPTION
Fixes #171.

The protocol the request was made with is now exposed as :protocol in
the request map.