### PR TITLE
Expose resource url resolution as a multimethod [#184]

### DIFF
--- a/ring-core/test/ring/util/test/response.clj
+++ b/ring-core/test/ring/util/test/response.clj
@@ -132,6 +132,11 @@
       (is (= (slurp (:body resp))
              "Hello World\n"))))
 
+  (testing "nil resource-data values"
+    (defmethod resource-data :http [_] {})
+    (with-redefs [io/resource (constantly (java.net.URL. "http://foo"))]
+      (is (= (response nil) (resource-response "whatever")))))
+
   (comment
     ;; This test requires the ability to have file names in the source
     ;; tree with non-ASCII characters in them encoded as UTF-8.  That


### PR DESCRIPTION
This opens up resource resolution for containers that use custom urls
for resources internally. Implementations of resource-info can
optionally wrap the values in the info map in delays if they are
potentially expensive to calculate.

