### PR TITLE
redirect optionally accepts a status

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -7,12 +7,22 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as str]))
 
+
+(def redirect-status-codes
+  {:moved-permanently 301
+   :found 302
+   :see-other 303
+   :temporary-redirect 307
+   :permanent-redirect 308})
+
 (defn redirect
-  "Returns a Ring response for an HTTP 302 redirect."
-  [url]
-  {:status  302
-   :headers {"Location" url}
-   :body    ""})
+  "Returns a Ring response for an HTTP 302 redirect. Status may be 
+  a key in redirect-status-codes or a numeric code. Defaults to 302"
+  ([url] (redirect url :found))
+  ([url status]
+   {:status  (redirect-status-codes status status)
+    :headers {"Location" url}
+    :body    ""}))
 
 (defn redirect-after-post
   "Returns a Ring response for an HTTP 303 redirect."

--- a/ring-core/test/ring/util/test/response.clj
+++ b/ring-core/test/ring/util/test/response.clj
@@ -7,7 +7,17 @@
 
 (deftest test-redirect
   (is (= {:status 302 :headers {"Location" "http://google.com"} :body ""}
-         (redirect "http://google.com"))))
+         (redirect "http://google.com")))
+  (are [x y] (= (->> x
+                     (redirect "/foo")
+                     :status)
+                y)
+       :moved-permanently 301
+       :found 302
+       :see-other 303
+       :temporary-redirect 307
+       :permanent-redirect 308
+       300 300))
 
 (deftest test-redirect-after-post
   (is (= {:status 303 :headers {"Location" "http://example.com"} :body ""}


### PR DESCRIPTION
redirect may be passed :found, :permanent or a numeric status code

supersedes https://github.com/ring-clojure/ring/pull/138 (enhanced, and I absentmindedly deleted my repo :smile:) 