### PR TITLE
Allow String body for wrap-params

### DIFF
--- a/ring-core/src/ring/middleware/params.clj
+++ b/ring-core/src/ring/middleware/params.clj
@@ -24,7 +24,11 @@
   [request encoding]
   (merge-with merge request
     (if-let [body (and (req/urlencoded-form? request) (:body request))]
-      (let [params (parse-params (slurp body :encoding encoding) encoding)]
+      (let [params (parse-params
+                     (if (string? body)
+                       body
+                       (slurp body :encoding encoding))
+                     encoding)]
         {:form-params params, :params params})
       {:form-params {}, :params {}})))
 

--- a/ring-core/test/ring/middleware/test/params.clj
+++ b/ring-core/test/ring/middleware/test/params.clj
@@ -44,6 +44,13 @@
     (is (= (:params resp) {"hello" "world"}))
     (is (= (:form-params resp) {"hello" "world"}))))
 
+(deftest wrap-params-string-body
+  (let [req {:headers {"content-type" "application/x-www-form-urlencoded;charset=UTF-16"}
+             :body    "hello=world"}
+        resp (wrapped-echo req)]
+    (is (= (:params resp) {"hello" "world"}))
+    (is (= (:form-params resp) {"hello" "world"}))))
+
 (deftest params-request-test
   (is (fn? params-request)))
 


### PR DESCRIPTION
Sometimes other middleware may have slurped the body
into a String before the wrap-params middleware gets
access to it.  As currently written, the wrap-params
middleware will still call 'slurp' on the string,
which results in trying to read a file from disk.
This commit adds a guard that will cause the middleware
to simply use the body as-is if it's already in
String format.