### PR TITLE
Map header names to lower case in locale-agnostic manner

### DIFF
--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -3,6 +3,7 @@
   (:require [clojure.java.io :as io]
             [clojure.string :as string])
   (:import (java.io File InputStream FileInputStream)
+           (java.util Locale)
            (javax.servlet.http HttpServlet
                                HttpServletRequest
                                HttpServletResponse)))
@@ -13,7 +14,7 @@
   (reduce
     (fn [headers, ^String name]
       (assoc headers
-        (.toLowerCase name)
+        (.toLowerCase name Locale/ENGLISH)
         (->> (.getHeaders request name)
              (enumeration-seq)
              (string/join ","))))
@@ -40,7 +41,7 @@
    :uri                (.getRequestURI request)
    :query-string       (.getQueryString request)
    :scheme             (keyword (.getScheme request))
-   :request-method     (keyword (.toLowerCase (.getMethod request)))
+   :request-method     (keyword (.toLowerCase (.getMethod request) Locale/ENGLISH))
    :headers            (get-headers request)
    :content-type       (.getContentType request)
    :content-length     (get-content-length request)


### PR DESCRIPTION
`toLowerCase` may default to a different locale that causes issues when transforming header names to lower case.