### PR TITLE
Recreate session when :recreate key is present in metadata

### DIFF
--- a/ring-core/src/ring/middleware/session.clj
+++ b/ring-core/src/ring/middleware/session.clj
@@ -42,8 +42,12 @@
 (defn- bare-session-response
   [response {session-key :session/key}  & [{:keys [store cookie-name cookie-attrs]}]]
   (let [new-session-key (if (contains? response :session)
-                          (if-let [session (response :session)]
-                            (store/write-session store session-key session)
+                         (if-let [session (response :session)]
+                            (if (:recreate (meta session))
+                              (do
+                                (store/delete-session store session-key)
+                                (store/write-session store nil session))
+                              (store/write-session store session-key session))
                             (if session-key
                               (store/delete-session store session-key))))
         session-attrs (:session-cookie-attrs response)

--- a/ring-core/test/ring/middleware/test/session.clj
+++ b/ring-core/test/ring/middleware/test/session.clj
@@ -180,3 +180,15 @@
     (testing "Session cookie attrs with active session"
       (let [response (handler {:foo "bar" :cookies {"ring-session" {:value sess-key}}})]
         (is (get-session-cookie response))))))
+
+(deftest session-is-recreated-when-recreate-key-present-in-metadata
+  (let [reader  (trace-fn (constantly {}))
+        writer  (trace-fn (constantly nil))
+        deleter (trace-fn (constantly nil))
+        store   (make-store reader writer deleter)
+        handler (constantly {:session ^:recreate {:foo "bar"}})
+        handler (wrap-session handler {:store store})]
+    (handler {:cookies {"ring-session" {:value "test"}}})
+    (is (= (trace reader) [["test"]]))
+    (is (= (trace writer) [[nil {:foo "bar"}]]))
+    (is (= (trace deleter) [["test"]]))))


### PR DESCRIPTION
This allows a session to be recreated by adding a :recreate key to
the :session value's metadata. A new session key is created and the
session data is moved to the new session. The old session is deleted.

This should provide a more functional interface for regenerating session
ids, which is needed to prevent session fixation attacks.