### PR TITLE
Add asynchronous request handling (almost per SPEC) and update middleware accordingly

### DIFF
--- a/ring-core/src/ring/middleware/content_type.clj
+++ b/ring-core/src/ring/middleware/content_type.clj
@@ -1,7 +1,8 @@
 (ns ring.middleware.content-type
   "Middleware for automatically adding a content type to response maps."
   (:require [ring.util.mime-type :refer [ext-mime-type]]
-            [ring.util.response :refer [content-type get-header]]))
+            [ring.util.response :refer [content-type get-header]]
+            [ring.util.async :refer (wrap-ring-async)]))
 
 (defn content-type-response
   "Adds a content-type header to response. See: wrap-content-type."
@@ -27,5 +28,5 @@
   {:arglists '([handler] [handler options])}
   [handler & [opts]]
   (fn [req]
-    (if-let [resp (handler req)]
+    (wrap-ring-async [resp (handler req)]
       (content-type-response resp req opts))))

--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -2,6 +2,7 @@
   "Middleware for parsing and generating cookies."
   (:import [org.joda.time DateTime Interval])
   (:require [ring.util.codec :as codec]
+            [ring.util.async :refer (wrap-ring-async)]
             [clojure.string :as str]
             [clj-time.core :refer [in-seconds]]
             [clj-time.format :refer [formatters unparse]]
@@ -152,7 +153,7 @@
                :or {decoder codec/form-decode-str
                     encoder codec/form-encode}}]]
   (fn [request]
-    (-> request
-        (cookies-request {:decoder decoder})
-        handler
-        (cookies-response {:encoder encoder}))))
+    (wrap-ring-async [resp (-> request
+                               (cookies-request {:decoder decoder})
+                               handler)]
+      (cookies-response resp {:encoder encoder}))))

--- a/ring-core/src/ring/middleware/file_info.clj
+++ b/ring-core/src/ring/middleware/file_info.clj
@@ -5,7 +5,8 @@
   ring.middleware.not-modified middleware instead."
   (:require [ring.util.response :as res]
             [ring.util.mime-type :refer [ext-mime-type]]
-            [ring.util.io :refer [last-modified-date]])
+            [ring.util.io :refer [last-modified-date]]
+            [ring.util.async :refer (wrap-ring-async)])
   (:import [java.io File]
            [java.util Date Locale TimeZone]
            [java.text SimpleDateFormat]))
@@ -66,5 +67,5 @@
    :deprecated "1.2"}
   [handler & [mime-types]]
   (fn [req]
-    (-> (handler req)
-        (file-info-response req mime-types))))
+    (wrap-ring-async [resp (handler req)]
+      (file-info-response resp req mime-types))))

--- a/ring-core/src/ring/middleware/flash.clj
+++ b/ring-core/src/ring/middleware/flash.clj
@@ -1,6 +1,7 @@
 (ns ring.middleware.flash
   "Middleware that adds session-based flash store that persists only to the
-  next request in the same session.")
+  next request in the same session."
+  (:require [ring.util.async :refer (wrap-ring-async)]))
 
 (defn flash-request
   "Adds :flash key to request from :_flash in session."
@@ -32,5 +33,5 @@
   This is useful for small messages that persist across redirects."
   [handler]
   (fn [request]
-    (if-let [resp (handler (flash-request request))]
+    (wrap-ring-async [resp (handler (flash-request request))]
       (flash-response resp (flash-request request)))))

--- a/ring-core/src/ring/middleware/head.clj
+++ b/ring-core/src/ring/middleware/head.clj
@@ -2,7 +2,8 @@
   "Middleware to simplify replying to HEAD requests.
 
   A response to a HEAD request should be identical to a GET request, with the
-  exception that a response to a HEAD request should have an empty body.")
+  exception that a response to a HEAD request should have an empty body."
+  (:require [ring.util.async :refer (wrap-ring-async)]))
 
 (defn head-request
   "Turns a HEAD request into a GET."
@@ -26,7 +27,5 @@
   {:added "1.1"}
   [handler]
   (fn [request]
-    (-> request
-        head-request
-        handler
-        (head-response request))))
+    (wrap-ring-async [resp (handler (head-request request))]
+      (head-response resp request))))

--- a/ring-core/src/ring/middleware/not_modified.clj
+++ b/ring-core/src/ring/middleware/not_modified.clj
@@ -3,7 +3,8 @@
   Last-Modified headers."
   (:require [ring.util.time :refer [parse-date]]
             [ring.util.response :refer [status get-header header]]
-            [ring.util.io :refer [close!]]))
+            [ring.util.io :refer [close!]]
+            [ring.util.async :refer (wrap-ring-async)]))
 
 (defn- etag-match? [request response]
   (if-let [etag (get-header response "ETag")]
@@ -49,5 +50,5 @@
   {:added "1.2"}
   [handler]
   (fn [request]
-    (-> (handler request)
-        (not-modified-response request))))
+    (wrap-ring-async [resp (handler request)]
+      (not-modified-response resp request))))

--- a/ring-core/src/ring/middleware/session.clj
+++ b/ring-core/src/ring/middleware/session.clj
@@ -9,7 +9,8 @@
     ring.middleware.session.cookie/cookie-store"
   (:require [ring.middleware.cookies :as cookies]
             [ring.middleware.session.store :as store]
-            [ring.middleware.session.memory :as mem]))
+            [ring.middleware.session.memory :as mem]
+            [ring.util.async :refer (wrap-ring-async)]))
 
 (defn- session-options
   [options]
@@ -99,5 +100,5 @@
      (let [options (session-options options)]
        (fn [request]
          (let [new-request (session-request request options)]
-           (-> (handler new-request)
-               (session-response new-request options)))))))
+           (wrap-ring-async [response (handler new-request)]
+             (session-response response new-request options)))))))

--- a/ring-core/src/ring/util/async.clj
+++ b/ring-core/src/ring/util/async.clj
@@ -1,0 +1,27 @@
+(ns ring.util.async)
+
+(defmacro wrap-ring-async
+  "Wraps a response altering expression in middleware such that it is
+  also applied to the response function given to an async reactor when
+  the type is :ring."
+  [[sym resp-expr] alter-expr]
+  `(when-let [~sym ~resp-expr]
+     (if-let [type# (:async ~sym)]
+       (if (= type# :ring)
+         (let [reactor# (:reactor ~sym)]
+           (assoc ~sym :reactor
+                  (fn [response-fn#]
+                    (reactor#
+                     (fn [~sym]
+                       (response-fn# ~alter-expr))))))
+         ~sym)
+       ~alter-expr)))
+
+
+(defmacro with-ring-async
+  "A small macro that binds a ring response function to the given
+  symbol, which can be used in the given body."
+  [[sym] & body]
+  `(let [reactor# (fn [~sym] ~@body)]
+     {:async :ring
+      :reactor reactor#}))


### PR DESCRIPTION
Hi maintainers and contributors,

Sorry for opening up an old (but still relevant?) discussion about async processing of requests [1]. I like the work and design in the async branch. This PR takes that design, and applies it to normal handling of requests. I.e., upgrades to WebSockets, streaming or long-polling were not my first concern. Being able to asynchronously "return" a normal ring response, as per SPEC, and applying all middleware to it as well, was.

As you can see, the changes it requires to the current middleware are small of size (mostly due to them being very well designed and split up in small functions, so kudos for that). The jetty server and middleware understand the `:async` type `:ring`, as that type indicates that the returned response will be a regular response map. Updates to the SPEC can be small in this regard. It is up to the actual underlying server which async types to support, but at least `:ring` could be supported whenever the server is able to handle requests asynchronously. I think the "reactor" design still allows upgrading to WebSockets and others. 

Current middleware can simply ignore other async types. The most difficult part is, I think, most of the existing middleware will need to checked whether they safely ignore the `{:async ... :reactor ...}` responses, and they need updating for sure when they want to make use of the reactor(s).

Let me know how you think about this and/or whether you'd like to see something changed, tested or discussed.

Cheers.

[1] https://groups.google.com/forum/#!topic/ring-clojure/JD9FLJFTVsg