### PR TITLE
Fix issue #48

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -87,7 +87,7 @@
   [^File dir]
   (first
     (filter
-      #(.startsWith (.toLowerCase (.getName ^File %)) "index.")
+      #(.startsWith (.toLowerCase (.getName ^File %)) "index.htm")
        (.listFiles dir))))
 
 (defn- safely-find-file [^String path opts]

--- a/ring-core/test/ring/assets/index.html
+++ b/ring-core/test/ring/assets/index.html
@@ -1,1 +1,1 @@
-index
+index html

--- a/ring-core/test/ring/assets/index.js
+++ b/ring-core/test/ring/assets/index.js
@@ -1,0 +1,1 @@
+index js

--- a/ring-core/test/ring/middleware/test/resource.clj
+++ b/ring-core/test/ring/middleware/test/resource.clj
@@ -14,7 +14,7 @@
   (let [handler (wrap-resource test-handler "/ring/assets")]
     (are [request body] (= (slurp (:body (handler request))) body)
       {:request-method :get, :uri "/foo.html"}      "foo"
-      {:request-method :get, :uri "/index.html"}    "index"
+      {:request-method :get, :uri "/index.html"}    "index html"
       {:request-method :get, :uri "/bars/foo.html"} "foo"
       {:request-method :get, :uri "/handler"}       "handler"
       {:request-method :post, :uri "/foo.html"}     "handler"

--- a/ring-core/test/ring/util/test/response.clj
+++ b/ring-core/test/ring/util/test/response.clj
@@ -164,6 +164,12 @@
         (is (.contains (slurp (:body resp)) "UTF-8"))))))
 
 (deftest test-file-response
+
+  (testing "index file defaults"
+    (let [resp (file-response "." {:root "test/ring/assets"})]
+           (is (= (resp :status) 200))
+           (is (= (slurp (resp :body)) "index html"))))
+
   (testing "response map"
     (let [resp (file-response "foo.html" {:root "test/ring/assets"})]
       (is (= (resp :status) 200))


### PR DESCRIPTION
```find-index-file``` returning index.htm*

I fixed the issue by limiting the file names which can be returned to only those,
which start with index.htm (so both index.htm & index.html) will be fine.