### PR TITLE
Keep throwing exceptions on broken namespaces

### DIFF
--- a/ring-devel/src/ring/middleware/reload.clj
+++ b/ring-devel/src/ring/middleware/reload.clj
@@ -4,19 +4,35 @@
   This middleware should be limited to use in development environments."
   (:require [ns-tracker.core :refer [ns-tracker]]))
 
+(defn- reloader [dirs retry?]
+  (let [modified-namespaces (ns-tracker dirs)
+        load-queue (java.util.concurrent.LinkedBlockingQueue.)]
+    (fn []
+      (locking load-queue
+        (doseq [ns-sym (modified-namespaces)]
+          (.offer load-queue ns-sym))
+        (loop []
+          (when-let [ns-sym (.peek load-queue)]
+            (if retry?
+              (do (require ns-sym :reload) (.remove load-queue))
+              (do (.remove load-queue) (require ns-sym :reload)))
+            (recur)))))))
+
 (defn wrap-reload
   "Reload namespaces of modified files before the request is passed to the
   supplied handler.
 
   Accepts the following options:
 
-  :dirs - A list of directories that contain the source files.
-          Defaults to [\"src\"]."
+  :dirs                   - A list of directories that contain the source files.
+                            Defaults to [\"src\"].
+  :reload-compile-errors? - If true, keep attempting to reload namespaces
+                            that have compile errors.  Defaults to true."
   {:arglists '([handler] [handler options])}
-  [handler & [options]]
-  (let [source-dirs (:dirs options ["src"])
-        modified-namespaces (ns-tracker source-dirs)]
+  [handler & [{:keys [dirs reload-compile-errors?]
+               :or {dirs ["src"]
+                    reload-compile-errors? true}}]]
+  (let [reload! (reloader dirs reload-compile-errors?)]
     (fn [request]
-      (doseq [ns-sym (modified-namespaces)]
-        (require ns-sym :reload))
+      (reload!)
       (handler request))))


### PR DESCRIPTION
This PR causes the reload middleware to keep throwing exceptions when a namespace is broken.  Rather than throw an exception once, and then go back to running the old version of the namespace.

I think this is a better behavior for development.  Without this PR, it's easy to get in a state where the web app seems to be working, but it's actually using an old version of the code.