### PR TITLE
Allow excluding SSL protocols & cipher suites

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -61,6 +61,10 @@
       :need (.setNeedClientAuth context true)
       :want (.setWantClientAuth context true)
       nil)
+    (if-let [exclude-ciphers (options :exclude-ciphers)]
+      (.addExcludeCipherSuites context (into-array String exclude-ciphers)))
+    (if-let [exclude-protocols (options :exclude-protocols)]
+      (.addExcludeProtocols context (into-array String exclude-protocols)))
     context))
 
 (defn- ^ServerConnector ssl-connector [server options]
@@ -106,6 +110,8 @@
   :ssl?                 - allow connections over HTTPS
   :ssl-port             - the SSL port to listen on (defaults to 443, implies
                           :ssl? is true)
+  :exclude-ciphers      - When :ssl? is true, exclude these cipher suites
+  :exclude-protocols    - When :ssl? is true, exclude these protocols
   :keystore             - the keystore to use for SSL connections
   :key-password         - the password to the keystore
   :truststore           - a truststore to use for SSL connections


### PR DESCRIPTION
This PR adds `:exclude-ciphers` and `:exclude-protocols` to `run-jetty`, which allows the removal of insecure SSL protocols and ciphers.

While this can be done with a `:configurator` function, it's a real pain to get at the `SslContextFactory`, and it'd be much nicer to set them up-front instead.

This is pretty speculative as-is, and I'd be happy to refactor it to be more generic, ex. by adding a configurator-like thing specific to the `SslContextFactory` or a way to send a preconfigured / partly preconfigured `SslContextFactory` instance to `run-jetty`.