### PR TITLE
in wrap-nested-params, override m when it's not a map

### DIFF
--- a/ring-core/src/ring/middleware/nested_params.clj
+++ b/ring-core/src/ring/middleware/nested_params.clj
@@ -29,7 +29,9 @@
         (if (= j "")
           (assoc-vec m k (assoc-nested {} js v))
           (assoc m k (assoc-nested (get m k {}) ks v))))
-      (assoc-conj m k v))
+      (if (map? m)
+        (assoc-conj m k v)
+        {k v}))
     v))
 
 (defn- param-pairs

--- a/ring-core/test/ring/middleware/test/nested_params.clj
+++ b/ring-core/test/ring/middleware/test/nested_params.clj
@@ -29,6 +29,14 @@
     (testing "parameters with newlines"
       (are [p r] (= (handler {:params p}) r)
         {"foo\nbar" "baz"} {"foo\nbar" "baz"}))
+    (testing "empty string"
+      (is (= {"foo" {"bar" "baz"}}
+             (handler {:params (sorted-map "foo" ""
+                                           "foo[bar]" "baz")}))))
+    (testing "double nested empty string"
+      (is (= {"foo" {"bar" {"baz" "bam"}}}
+             (handler {:params (sorted-map "foo[bar]" ""
+                                           "foo[bar][baz]" "bam")}))))
     (testing "parameters are already nested"
       (is (= {"foo" [["bar" "baz"] ["asdf" "zxcv"]]}
              (handler {:params {"foo" [["bar" "baz"] ["asdf" "zxcv"]]}}))))


### PR DESCRIPTION
I noticed an exception being thrown when the params came in like `?foo=&foo[bar]=baz`. The empty string fouled things up.

I'm not sure what the best thing for ring to do in this situation, but throwing an exception in the wrapper makes it challenging to code around. This patch will replace the non-map with a new map of `{k v}`.

