### PR TITLE
When returning index files, prefer .html and .htm files - fixes #48

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -82,13 +82,23 @@
       (set)
       (contains? "..")))
 
+(defn- find-file-named [^File dir ^String filename]
+  (let [path (File. dir filename)]
+    (if (.isFile path)
+      path)))
+
+(defn- find-file-starting-with [^File dir ^String prefix]
+  (first
+   (filter
+    #(.startsWith (.toLowerCase (.getName ^File %)) prefix)
+    (.listFiles dir))))
+
 (defn- find-index-file
   "Search the directory for an index file."
   [^File dir]
-  (first
-    (filter
-      #(.startsWith (.toLowerCase (.getName ^File %)) "index.")
-       (.listFiles dir))))
+  (or (find-file-named dir "index.html")
+      (find-file-named dir "index.htm")
+      (find-file-starting-with dir "index.")))
 
 (defn- safely-find-file [^String path opts]
   (if-let [^String root (:root opts)]

--- a/ring-core/test/ring/assets/index.asp
+++ b/ring-core/test/ring/assets/index.asp
@@ -1,0 +1,1 @@
+asp index

--- a/ring-core/test/ring/assets/index.js
+++ b/ring-core/test/ring/assets/index.js
@@ -1,0 +1,1 @@
+javascript index


### PR DESCRIPTION
After that, fall back to the old behaviour, which might end up returning
index.php, index.JS, index.GIF or anything else.