### PR TITLE
Bump to next patch version of commons-fileupload.

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [ring/ring-codec "1.0.1"]
                  [commons-io "2.5"]
-                 [commons-fileupload "1.3.1"]
+                 [commons-fileupload "1.3.2"]
                  [clj-time "0.11.0"]
                  [crypto-random "1.2.0"]
                  [crypto-equality "1.0.0"]]


### PR DESCRIPTION
commons-fileupload 1.3.2 has a fix for a known
vulnerability (http://www.cvedetails.com/cve/CVE-2016-3092/). This
commit addresses https://github.com/ring-clojure/ring/issues/255.