### PR TITLE
Fix 404 response in async Jetty adapter

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -33,11 +33,10 @@
         (handler
          (servlet/build-request-map request)
          (fn [response-map]
-           (servlet/update-servlet-response response context response-map)
-           (.setHandled base-request true))
+           (servlet/update-servlet-response response context response-map))
          (fn [^Throwable exception]
-           (.sendError response 500 (.getMessage exception))
-           (.setHandled base-request true)))))))
+           (.sendError response 500 (.getMessage exception))))
+        (.setHandled base-request true)))))
 
 (defn- ^ServerConnector server-connector [server & factories]
   (ServerConnector. server (into-array ConnectionFactory factories)))

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -252,6 +252,12 @@
             :headers {"Content-Type" "text/plain"}
             :body    "Hello World"}))
 
+(defn- hello-world-cps-future [request respond raise]
+  (future
+    (respond {:status  200
+            :headers {"Content-Type" "text/plain"}
+            :body    "Hello World"})))
+
 (defn- hello-world-streaming [request respond raise]
   (future
     (respond
@@ -269,6 +275,14 @@
                        (.flush w)))))})))
 
 (deftest run-jetty-cps-test
+  (testing "async response in future"
+    (with-server hello-world-cps-future {:port test-port, :async? true}
+      (let [response (http/get test-url)]
+        (is (= (:status response) 200))
+        (is (.startsWith (get-in response [:headers "content-type"])
+                         "text/plain"))
+        (is (= (:body response) "Hello World")))))
+
   (testing "async response"
     (with-server hello-world-cps {:port test-port, :async? true}
       (let [response (http/get test-url)]


### PR DESCRIPTION
When I try to wrap the call of async handler's response function into a future (like the new added test case), I finally got a 404 not found as response. I modified some code, and pass the test case.