### PR TITLE
Fix reflection warnings

### DIFF
--- a/ring-core/src/ring/core/protocols.clj
+++ b/ring-core/src/ring/core/protocols.clj
@@ -1,6 +1,7 @@
 (ns ring.core.protocols
   "Protocols necessary for Ring."
   {:added "1.6"}
+  (:import [java.io Writer OutputStream])
   (:require [clojure.java.io :as io]
             [ring.util.response :as response]))
 
@@ -10,7 +11,7 @@
     "Write a value representing a response body to an output stream. The stream
     will be closed after the value had been written."))
 
-(defn- response-writer [response output-stream]
+(defn- ^Writer response-writer [response output-stream]
   (if-let [charset (response/get-charset response)]
     (io/writer output-stream :encoding charset)
     (io/writer output-stream)))
@@ -26,11 +27,11 @@
       (doseq [chunk body]
         (.write writer (str chunk)))))
   java.io.InputStream
-  (write-body-to-stream [body _ output-stream]
+  (write-body-to-stream [body _ ^OutputStream output-stream]
     (with-open [out output-stream, body body]
       (io/copy body out)))
   java.io.File
-  (write-body-to-stream [body _ output-stream]
+  (write-body-to-stream [body _ ^OutputStream output-stream]
     (with-open [out output-stream]
       (io/copy body out)))
   nil


### PR DESCRIPTION
The `1.6.0-beta6` gives the following reflection warnings:

```
Reflection warning, ring/core/protocols.clj:22:7 - call to method write can't be resolved (target class is unknown).
Reflection warning, ring/core/protocols.clj:21:5 - reference to field close can't be resolved.
Reflection warning, ring/core/protocols.clj:27:9 - call to method write can't be resolved (target class is unknown).
Reflection warning, ring/core/protocols.clj:27:9 - call to method write can't be resolved (target class is unknown).
Reflection warning, ring/core/protocols.clj:25:5 - reference to field close can't be resolved.
Reflection warning, ring/core/protocols.clj:30:5 - reference to field close can't be resolved.
Reflection warning, ring/core/protocols.clj:34:5 - reference to field close can't be resolved.
```

FIxed in this PR.
