### PR TITLE
Prevent wrap-stacktrace HTML from overflowing

### DIFF
--- a/ring-devel/resources/ring/css/stacktrace.css
+++ b/ring-devel/resources/ring/css/stacktrace.css
@@ -48,6 +48,7 @@ h1 {
 .trace {
     width: 90%;
     margin: auto;
+    overflow: scroll;
 }
 
 .trace table {


### PR DESCRIPTION
Before:

<img width="1107" alt="screen shot 2016-11-25 at 3 21 36 pm" src="https://cloud.githubusercontent.com/assets/26643/20634828/e7df052a-b322-11e6-98ec-25f393f53674.png">

After:

<img width="1106" alt="screen shot 2016-11-25 at 3 22 45 pm" src="https://cloud.githubusercontent.com/assets/26643/20634839/157f9512-b323-11e6-8926-a1123b082655.png">