### PR TITLE
Updating Clojure to 1.8.0

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -3,7 +3,7 @@
   :url "https://github.com/ring-clojure/ring"
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
-  :dependencies [[org.clojure/clojure "1.5.1"]
+  :dependencies [[org.clojure/clojure "1.8.0"]
                  [ring/ring-core "1.6.0-beta7"]
                  [ring/ring-devel "1.6.0-beta7"]
                  [ring/ring-jetty-adapter "1.6.0-beta7"]


### PR DESCRIPTION
Is there any downside of upgrading from 1.5.1 to 1.8.0? I am not aware of any.