### PR TITLE
Ignore unrecognized cookie attrs

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -70,8 +70,7 @@
 (defn- valid-attr?
   "Is the attribute valid?"
   [[key value]]
-  (and (contains? set-cookie-attrs key)
-       (not (.contains (str value) ";"))
+  (and (not (.contains (str value) ";"))
        (case key
          :max-age (or (instance? Interval value) (integer? value))
          :expires (or (instance? DateTime value) (string? value))
@@ -82,7 +81,8 @@
   "Write a map of cookie attributes to a string."
   [attrs]
   {:pre [(every? valid-attr? attrs)]}
-  (for [[key value] attrs]
+  (for [[key value] attrs
+        :when (contains? set-cookie-attrs key)]
     (let [attr-name (name (set-cookie-attrs key))]
       (cond
         (instance? Interval value) (str ";" attr-name "=" (in-seconds value))

--- a/ring-core/test/ring/middleware/test/cookies.clj
+++ b/ring-core/test/ring/middleware/test/cookies.clj
@@ -102,8 +102,13 @@
     (is (= {"Set-Cookie" (list "a=b" "c=d")}
            (:headers resp)))))
 
+(deftest wrap-cookies-unrecognized-attrs
+  (let [response {:cookies {"a" {:value "foo" :unrecognized true}}}
+        handler  (wrap-cookies (constantly response))]
+    (is (handler {}))))
+
 (deftest wrap-cookies-invalid-attrs
-  (let [response {:cookies {"a" {:value "foo" :invalid true}}}
+  (let [response {:cookies {"a" {:value "foo" :path "/;Bar"}}}
         handler  (wrap-cookies (constantly response))]
     (is (thrown? AssertionError (handler {})))))
 


### PR DESCRIPTION
Allow, but ignore unrecognized cookie attributes. Fixes #232 