### PR TITLE
Add :jmx? option to adapter

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,8 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [ring/ring-core "1.6.2"]
                  [ring/ring-servlet "1.6.2"]
-                 [org.eclipse.jetty/jetty-server "9.2.21.v20170120"]]
+                 [org.eclipse.jetty/jetty-server "9.2.21.v20170120"]
+                 [org.eclipse.jetty/jetty-jmx "9.2.21.v20170120"]]
   :aliases {"test-all" ["with-profile" "default:+1.6:+1.7:+1.8" "test"]}
   :profiles
   {:dev {:dependencies [[clj-http "2.2.0"]]

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -4,7 +4,8 @@
             [clj-http.client :as http]
             [clojure.java.io :as io]
             [ring.core.protocols :as p])
-  (:import [org.eclipse.jetty.util.thread QueuedThreadPool]
+  (:import [org.eclipse.jetty.jmx MBeanContainer]
+           [org.eclipse.jetty.util.thread QueuedThreadPool]
            [org.eclipse.jetty.util BlockingArrayQueue]
            [org.eclipse.jetty.server Server Request SslConnectionFactory]
            [org.eclipse.jetty.server.handler AbstractHandler]
@@ -258,6 +259,14 @@
           server   (run-jetty echo-handler options)]
       (try
         (is (contains? (exclude-protocols server) protocol))
+        (finally
+          (.stop server)))))
+
+  (testing "enable Jetty JMX integration"
+    (let [options {:port test-port :join? false :jmx? true}
+          ^Server server (run-jetty hello-world options)]
+      (try
+        (is (instance? MBeanContainer (.getBean server MBeanContainer)))
         (finally
           (.stop server)))))
 


### PR DESCRIPTION
Add :jmx? option to adapter for Jetty JMX integration.

http://www.eclipse.org/jetty/documentation/9.2.22.v20170531/jmx-chapter.html