### PR TITLE
Bump commons-fileupload to 1.3.3

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.5.1"]
                  [ring/ring-codec "1.0.1"]
                  [commons-io "2.5"]
-                 [commons-fileupload "1.3.2"]
+                 [commons-fileupload "1.3.3"]
                  [clj-time "0.11.0"]
                  [crypto-random "1.2.0"]
                  [crypto-equality "1.0.0"]]


### PR DESCRIPTION
Version 1.3.3 patches a code execution exploit:
http://www.cvedetails.com/cve/CVE-2016-1000031/

The release notes for 1.3.3. states that no client code will need
changing to accommodate this bugfix.