### PR TITLE
Add bad-request response builder to ring.util.response [ring-core]

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -44,6 +44,14 @@
       :headers {"Location" url}
       :body    body}))
 
+(defn bad-request
+  "Returns a 400 'bad request' response."
+  {:added "1.7"}
+  [body]
+  {:status  400
+   :headers {}
+   :body    body})
+
 (defn not-found
   "Returns a 404 'not found' response."
   {:added "1.1"}

--- a/ring-core/test/ring/util/test/response.clj
+++ b/ring-core/test/ring/util/test/response.clj
@@ -23,6 +23,10 @@
   (is (= {:status 303 :headers {"Location" "http://example.com"} :body ""}
          (redirect-after-post "http://example.com"))))
 
+(deftest test-bad-request
+  (is (= {:status 400 :headers {} :body "Bad Request"}
+         (bad-request "Bad Request"))))
+
 (deftest test-not-found
   (is (= {:status 404 :headers {} :body "Not found"}
          (not-found "Not found"))))


### PR DESCRIPTION
Add a response builder to notify callers that the request was invalid.
Fraternal twin to r.u.r/not-found

https://http.cat/400