### PR TITLE
let handler handle request first

### DIFF
--- a/ring-core/src/ring/middleware/file.clj
+++ b/ring-core/src/ring/middleware/file.clj
@@ -47,7 +47,7 @@
    (ensure-dir root-path)
    (fn
      ([request]
-      (or (file-request request root-path options) (handler request)))
+      (or (handler request) (file-request request root-path options) ))
      ([request respond raise]
       (if-let [response (file-request request root-path options)]
         (respond response)


### PR DESCRIPTION
I have a handler that handles *.chp files. I want to use ring.middleware.file/wrap-file to handle  all other files. However, ring.middleware.file/wrap-file will handle  *.chp files too

The middleware should give the handler the opportunity to handle the file first.  

I created my own hack at https://bitbucket.org/sonwh98/cpress/src/0b94ad02fbef4b6153836fd5e00ed1b5457befae/src/clj/stigmergy/ring/middleware/file.clj?at=master&fileviewer=file-view-default 

