### PR TITLE
Add default response to util.response/status

### DIFF
--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -70,8 +70,12 @@
 
 (defn status
   "Returns an updated Ring response with the given status."
-  [resp status]
-  (assoc resp :status status))
+  ([status]
+   {:status  status
+    :headers {}
+    :body    nil})
+  ([resp status]
+   (assoc resp :status status)))
 
 (defn header
   "Returns an updated Ring response with the specified header added."

--- a/ring-core/test/ring/util/test/response.clj
+++ b/ring-core/test/ring/util/test/response.clj
@@ -44,7 +44,10 @@
          (response "foobar"))))
 
 (deftest test-status
-  (is (= {:status 200 :body ""} (status {:status nil :body ""} 200))))
+  (testing "with response"
+    (is (= {:status 200 :body ""} (status {:status nil :body ""} 200))))
+  (testing "without response"
+    (is (= {:status 200 :headers {} :body nil} (status 200)))))
 
 (deftest test-content-type
   (is (= {:status 200 :headers {"Content-Type" "text/html" "Content-Length" "10"}}


### PR DESCRIPTION
Sometimes when your API needs to respond with only status code you need to provide empty response for status function like `(status {} 422)`. I suggest we can omit default response for util.response/status when it's not needed.