### PR TITLE
Add support for byte array response bodies

### DIFF
--- a/ring-core/src/ring/core/protocols.clj
+++ b/ring-core/src/ring/core/protocols.clj
@@ -17,6 +17,10 @@
     (io/writer output-stream)))
 
 (extend-protocol StreamableResponseBody
+  (Class/forName "[B")
+  (write-body-to-stream [body _ ^OutputStream output-stream]
+    (with-open [out output-stream]
+      (.write out ^bytes body)))
   String
   (write-body-to-stream [body response output-stream]
     (with-open [writer (response-writer response output-stream)]

--- a/ring-core/test/ring/core/test/protocols.clj
+++ b/ring-core/test/ring/core/test/protocols.clj
@@ -4,6 +4,12 @@
             [ring.core.protocols :refer :all]))
 
 (deftest test-write-body-defaults
+  (testing "byte-array"
+    (let [output   (java.io.ByteArrayOutputStream.)
+          response {:body (.getBytes "Hello World")}]
+      (write-body-to-stream (:body response) response output)
+      (is (= "Hello World" (.toString output)))))
+
   (testing "strings"
     (let [output   (java.io.ByteArrayOutputStream.)
           response {:body "Hello World"}]


### PR DESCRIPTION
Writing values to byte-arrays is really fast and it enables use of NIO.

* Aleph supports these already
* Immutant will
* Http-kit [might too](https://github.com/http-kit/http-kit/pull/379).

Byte-arrays can also be `slurp`ed - extending primitive arrays is supported (and used) by `clojure.core`. Only catch https://dev.clojure.org/jira/browse/CLJ-1381 - needs to be first in `extend-protocol`.