### PR TITLE
Remove trailing slash in wrap-resource path

### DIFF
--- a/ring-core/src/ring/middleware/resource.clj
+++ b/ring-core/src/ring/middleware/resource.clj
@@ -3,7 +3,8 @@
   (:require [ring.util.codec :as codec]
             [ring.util.response :as response]
             [ring.util.request :as request]
-            [ring.middleware.head :as head]))
+            [ring.middleware.head :as head]
+            [clojure.string :as str]))
 
 (defn resource-request
   "If request matches a static resource, returns it in a response map.
@@ -58,6 +59,7 @@
   ([handler root-path]
    (wrap-resource handler root-path {}))
   ([handler root-path options]
-   (if (:prefer-handler? options)
-     (wrap-resource-prefer-handler   handler root-path options)
-     (wrap-resource-prefer-resources handler root-path options))))
+   (let [root-path (str/replace root-path #"/$" "")]
+     (if (:prefer-handler? options)
+       (wrap-resource-prefer-handler   handler root-path options)
+       (wrap-resource-prefer-resources handler root-path options)))))

--- a/ring-core/test/ring/middleware/test/resource.clj
+++ b/ring-core/test/ring/middleware/test/resource.clj
@@ -35,7 +35,14 @@
     (are [request body] (= (slurp (:body (no-loader request))) body)
          {:request-method :get, :uri "/foo.html"} "foo")
     (are [request body] (= (slurp (:body (with-loader request))) body)
-      {:request-method :get, :uri "/foo.html"} "foo-in-jar")))
+      {:request-method :get, :uri "/foo.html"} "foo-in-jar")
+    (testing "does accept trailing slash in asset path"
+      (let [no-loader-s   (wrap-resource test-handler "/ring/assets/")
+            with-loader-s (wrap-resource test-handler "/ring/assets/" {:loader loader})]
+        (are [request body] (= (slurp (:body (no-loader-s request))) body)
+          {:request-method :get, :uri "/foo.html"} "foo")
+        (are [request body] (= (slurp (:body (with-loader-s request))) body)
+          {:request-method :get, :uri "/foo.html"} "foo-in-jar")))))
 
 (deftest wrap-resource-symlinks-test
   (testing "doesn't follow symlinks by default"


### PR DESCRIPTION
This removes a possible trailing slash in the argument `root-path` of the `wrap-resource` function which solves #339.