### PR TITLE
Add support for javascript modules mime-type

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -51,6 +51,7 @@
    "mov"      "video/quicktime"
    "m3u8"     "application/x-mpegurl"
    "m4v"      "video/mp4"
+   "mjs"      "text/javascript"
    "mp3"      "audio/mpeg"
    "mp4"      "video/mp4"
    "mpd"      "application/dash+xml"


### PR DESCRIPTION
Javascript's module system has a suggested `mjs` extension, which has received
some degree of adoption (Node [1]), tooling support (Babel [2], VSCode [3]), and
is already present on Google's JS Modules documentation [4].

The only requirement is that they're sent with JS's MIME.

[1] - http://2ality.com/2017/05/es-module-specifiers.html#why-new-extension
[2] - https://github.com/babel/babel/pull/5624
[3] - https://github.com/Microsoft/vscode/pull/25747
[4] - https://developers.google.com/web/fundamentals/primers/modules