### PR TITLE
Use three-letter timezones from rfc822 for chrome/safari compatibility

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -3,8 +3,8 @@
   (:import [org.joda.time DateTime Interval])
   (:require [ring.util.codec :as codec]
             [clojure.string :as str]
-            [clj-time.core :refer [in-seconds]]
-            [clj-time.format :refer [formatters unparse with-locale]]
+            [clj-time.core :refer [in-seconds time-zone-for-id]]
+            [clj-time.format :refer [formatter unparse with-locale]]
             [ring.util.parsing :refer [re-token]]))
 
 (def ^{:private true, :doc "RFC6265 cookie-octet"}
@@ -33,7 +33,7 @@
    :lax "Lax"})
 
 (def ^:private rfc822-formatter
-  (with-locale (formatters :rfc822) java.util.Locale/US))
+  (formatter "EEE, dd MMM yyyy HH:mm:ss z" (time-zone-for-id "GMT")))
 
 (defn- parse-cookie-header
   "Turn a HTTP Cookie header into a list of name/value pairs."


### PR DESCRIPTION
Although the various specs prefer [1] numeric timezones allowed by rfc822 [2] for the cookie `expires` field, some browsers discard cookies with dates in this format (latest chrome and safari at the time of writing). Firefox does seem to respect this aspect of the specs.

[1] https://tools.ietf.org/html/rfc1123#section-5.2.14
[2] https://tools.ietf.org/html/rfc822#section-5.1

Kudos to @neilprosser for spotting this!