### PR TITLE
Use three-letter timezones from rfc822 in cookies

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -4,7 +4,7 @@
   (:require [ring.util.codec :as codec]
             [clojure.string :as str]
             [clj-time.core :refer [in-seconds]]
-            [clj-time.format :refer [formatters unparse with-locale]]
+            [clj-time.format :refer [formatter unparse with-locale]]
             [ring.util.parsing :refer [re-token]]))
 
 (def ^{:private true, :doc "RFC6265 cookie-octet"}
@@ -33,7 +33,7 @@
    :lax "Lax"})
 
 (def ^:private rfc822-formatter
-  (with-locale (formatters :rfc822) java.util.Locale/US))
+  (with-locale (formatter "EEE, dd MMM yyyy HH:mm:ss z") java.util.Locale/US))
 
 (defn- parse-cookie-header
   "Turn a HTTP Cookie header into a list of name/value pairs."

--- a/ring-core/test/ring/middleware/test/cookies.clj
+++ b/ring-core/test/ring/middleware/test/cookies.clj
@@ -161,7 +161,7 @@
                       :expires (date-time 2015 12 31)}}
         handler (constantly {:cookies cookies})
         resp    ((wrap-cookies handler) {})
-        expires "Thu, 31 Dec 2015 00:00:00 +0000"]
+        expires "Thu, 31 Dec 2015 00:00:00 UTC"]
     (is (= {"Set-Cookie" #{"a=b" "Path=/" "Secure" "HttpOnly" (str "Expires=" expires)}}
            (split-set-cookie (:headers resp))))))
 
@@ -174,7 +174,7 @@
                           :expires (date-time 2015 12 31)}}
             handler (constantly {:cookies cookies})
             resp    ((wrap-cookies handler) {})
-            expires "Thu, 31 Dec 2015 00:00:00 +0000"]
+            expires "Thu, 31 Dec 2015 00:00:00 UTC"]
         (is (= {"Set-Cookie" #{"a=b" "Path=/" "Secure" "HttpOnly" (str "Expires=" expires)}}
           (split-set-cookie (:headers resp)))))
       (finally


### PR DESCRIPTION
Although the various specs prefer [1] numeric timezones allowed by rfc822 [2] for the cookie expires field, some browsers discard cookies with dates in this format (latest chrome and safari at the time of writing). Firefox does seem to respect this aspect of the specs.

I don't currently have any other supporting evidence, except that @neilprosser I have tried this on Linux with Chrome, Chromium and Firefox, and on OSx with Safari, Chrome and Firefox.

[1] https://tools.ietf.org/html/rfc1123#section-5.2.14
[2] https://tools.ietf.org/html/rfc822#section-5.1

Kudos to @neilprosser for spotting this!