### PR TITLE
Fix Jetty vulnerabilities

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.7.0"]
                  [ring/ring-servlet "1.7.0"]
-                 [org.eclipse.jetty/jetty-server "9.2.24.v20180105"]]
+                 [org.eclipse.jetty/jetty-server "9.4.12.v20180830"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9" "test"]}
   :profiles
   {:dev {:dependencies [[clj-http "2.2.0"]]


### PR DESCRIPTION
Fixes vulnerabilties and End Of LIfe support for Jetty Server
dependency. Update from : 9.2.24.v20180105 to latest
9.4.12.v20180830".

CVE-2018-12538 HttpSessions present specifically in the FileSystem’s
storage could be hijacked/accessed by an unauthorized user.

CVE-2018-12536 InvalidPathException Message reveals webapp system
path. In Eclipse Jetty Server, all 9.x versions, on webapps deployed
using default Error Handling, when an intentionally bad query arrives
that doesn't match a dynamic url-pattern, and is eventually handled by
the DefaultServlet's static file serving, the bad characters can
trigger a java.nio.file.InvalidPathException which includes the full
path to the base resource directory that the DefaultServlet and/or
webapp is using. If this InvalidPathException is then handled by the
default Error Handler, the InvalidPathException message is included in
the error response, revealing the full server path to the requesting
system.

https://bugs.eclipse.org/bugs/show_bug.cgi?id=535670
https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-12536

CVE-2017-7658 Too Tolerant Parser, Double Content-Length + Transfer-
Encoding + Whitespace.

CVE-2017-7657 HTTP/1.1 Request smuggling with carefully crafted body
content (Does not apply to HTTP/1.0 or HTTP/2).

CVE-2017-7656 HTTP Request Smuggling when used with invalid request
headers (for HTTP/0.9).

Resolves: #347