### PR TITLE
Prevent 2nd call of handler on unhandled exception

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -16,16 +16,17 @@
            [org.eclipse.jetty.util BlockingArrayQueue]
            [org.eclipse.jetty.util.thread ThreadPool QueuedThreadPool]
            [org.eclipse.jetty.util.ssl SslContextFactory]
-           [javax.servlet AsyncContext]
+           [javax.servlet AsyncContext DispatcherType]
            [javax.servlet.http HttpServletRequest HttpServletResponse]))
 
 (defn- ^AbstractHandler proxy-handler [handler]
   (proxy [AbstractHandler] []
     (handle [_ ^Request base-request request response]
-      (let [request-map  (servlet/build-request-map request)
-            response-map (handler request-map)]
-        (servlet/update-servlet-response response response-map)
-        (.setHandled base-request true)))))
+      (when-not (= (.getDispatcherType request) DispatcherType/ERROR)
+        (let [request-map  (servlet/build-request-map request)
+              response-map (handler request-map)]
+          (servlet/update-servlet-response response response-map)
+          (.setHandled base-request true))))))
 
 (defn- ^AbstractHandler async-proxy-handler [handler timeout]
   (proxy [AbstractHandler] []


### PR DESCRIPTION
Since version `9.4.12.v20180830`, Jetty's `AbstractCachingHandler` calls `handle` a second time when an exception is thrown. This is so handlers can render custom error pages.

However in `ring` this would normally be done elsewhere in middleware - so this causes the normal handler to be called a second time on unhandled error, which causes a duplication of any side-effects of the handler function.

The second time `handle` is called, it's caled with a `DispatcherType` of `DispatcherType/ERROR` - so this commit checks for this `DispatcherType` and skips calling the user's ring handler in this case. This leads to a generic Jetty error page being returned.

Async handlers don't seem to be affected in the same way, so I haven't made the same change there, but I've added a test case so that if the same thing does start happening, it will be caught.

Fixes #364.