### PR TITLE
Update Jetty to 9.4.19

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.7.1"]
                  [ring/ring-servlet "1.7.1"]
-                 [org.eclipse.jetty/jetty-server "9.4.12.v20180830"]]
+                 [org.eclipse.jetty/jetty-server "9.4.19.v20190610"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9" "test"]}
   :profiles
   {:dev {:dependencies [[clj-http "2.2.0"]]


### PR DESCRIPTION
Jetty version 9.4.12 has the following vulnerabilities that are fixed in
version 9.4.19: CVE-2019-10247, CVE-2019-10241.