### PR TITLE
Add :none as possible :same-site value

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -31,7 +31,8 @@
        :doc "Values defined by RFC6265 that apply to the SameSite cookie attribute header."}
   same-site-values
   {:strict "Strict"
-   :lax "Lax"})
+   :lax "Lax"
+   :none "None"})
 
 (defn- parse-cookie-header
   "Turn a HTTP Cookie header into a list of name/value pairs."

--- a/ring-core/test/ring/middleware/test/cookies.clj
+++ b/ring-core/test/ring/middleware/test/cookies.clj
@@ -118,7 +118,7 @@
            (split-set-cookie (:headers resp))))))
 
 (deftest wrap-cookies-accepts-same-site
-  (testing "Allows :strict and :lax values"
+  (testing "Allows :strict, :lax and :none values"
     (let [cookies {"a" {:value "b" :path "/" :same-site :strict}}
           handler (constantly {:cookies cookies})
           resp    ((wrap-cookies handler) {})]
@@ -129,6 +129,12 @@
           handler (constantly {:cookies cookies})
           resp    ((wrap-cookies handler) {})]
       (is (= {"Set-Cookie" #{"a=b" "Path=/" "SameSite=Lax"}}
+             (split-set-cookie (:headers resp)))))
+
+    (let [cookies {"a" {:value "b" :path "/" :same-site :none}}
+          handler (constantly {:cookies cookies})
+          resp    ((wrap-cookies handler) {})]
+      (is (= {"Set-Cookie" #{"a=b" "Path=/" "SameSite=None"}}
              (split-set-cookie (:headers resp))))))
 
   (testing "Disallows other values"


### PR DESCRIPTION
According to https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-03#section-4.1 Google is proposing a change to the cookie spec that will add the value "None" to the same-site HTTP header. This adds :none as an acceptable key for the :same-site header value.

Implements issue #373:

ring-clojure/ring#373