### PR TITLE
Render stacktrace as HTML only for text/html

### DIFF
--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -67,10 +67,10 @@
                [:table
                  [:tbody (map elem-partial (:trace-elems cause))]]]])]])))
 
-(defn- js-ex-response [e]
+(defn- text-ex-response [e]
   (-> (response (with-out-str (pst e)))
       (status 500)
-      (content-type "text/javascript")))
+      (content-type "text/plain")))
 
 (defn- html-ex-response [ex]
   (-> (response (html-exception ex))
@@ -79,12 +79,14 @@
 
 (defn- ex-response
   "Returns a response showing debugging information about the exception.
-  Currently supports delegation to either js or html exception views."
+
+  Renders HTML if that's in the accept header (indicating that the URL was
+  opened in a browser), but defaults to plain text."
   [req ex]
   (let [accept (get-in req [:headers "accept"])]
-    (if (and accept (re-find #"^text/javascript" accept))
-      (js-ex-response ex)
-      (html-ex-response ex))))
+    (if (and accept (re-find #"^text/html" accept))
+      (html-ex-response ex)
+      (text-ex-response ex))))
 
 (defn wrap-stacktrace-web
   "Wrap a handler such that exceptions are caught and a response containing


### PR DESCRIPTION
#### Why is this change necessary:

The stacktrace middleware was rendering the stack trace as plain text
when the Accept header started with "text/javascript" and HTML
otherwise. This caused HTML to be rendered in many situations where it
was undesirable. Examples:

- when curling a URL from a terminal without an accept header

- when making AJAX requests (which would often send
  "application/json", the nonstandard "application/edn", or nothing at
  all in the Accept header) and inspecting a 500 in the browser
  developer tools

- when making requests from Swagger (which sends "Accept:
  application/json" and render the response verbatim).

#### How does this change address the issue:

Invert the logic so that we render HTML only when the accept header
starts with "text/html" (as is typically the case when viewed in a
browser window). Return plain text in all other cases.