### PR TITLE
Add type hint for server-connector

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -43,7 +43,7 @@
         (.setHandled base-request true)))))
 
 (defn- ^ServerConnector server-connector [^Server server & factories]
-  (ServerConnector. server (into-array ConnectionFactory factories)))
+  (ServerConnector. server #^"[Lorg.eclipse.jetty.server.ConnectionFactory;" (into-array ConnectionFactory factories)))
 
 (defn- ^HttpConfiguration http-config [options]
   (doto (HttpConfiguration.)


### PR DESCRIPTION
Because:
- When running a Graal native image [using ring-jetty](https://github.com/BrunoBonacci/graalvm-clojure/tree/master/ring-jetty), Graal isn't able to resolve which method to call. Adding the varargs type hint fixes this.

Without this patch, the native image will build, but fail with:

```java
Exception in thread "main" java.lang.ClassNotFoundException: org.eclipse.jetty.server.ServerConnector
	at com.oracle.svm.core.hub.ClassForNameSupport.forName(ClassForNameSupport.java:60)
	at java.lang.Class.forName(DynamicHub.java:1174)
	at clojure.lang.RT.classForName(RT.java:2207)
	at clojure.lang.RT.classForName(RT.java:2216)
	at ring.adapter.jetty$server_connector.invokeStatic(jetty.clj:44)
	at ring.adapter.jetty$server_connector.doInvoke(jetty.clj:44)
	at clojure.lang.RestFn.invoke(RestFn.java:423)
	at ring.adapter.jetty$http_connector.invokeStatic(jetty.clj:57)
	at ring.adapter.jetty$http_connector.invoke(jetty.clj:55)
	at ring.adapter.jetty$create_server.invokeStatic(jetty.clj:122)
	at ring.adapter.jetty$create_server.invoke(jetty.clj:119)
	at ring.adapter.jetty$run_jetty.invokeStatic(jetty.clj:164)
	at ring.adapter.jetty$run_jetty.invoke(jetty.clj:127)
	at simple.main$_main.invokeStatic(main.clj:15)
	at simple.main$_main.invoke(main.clj:13)
	at clojure.lang.AFn.applyToHelper(AFn.java:152)
	at clojure.lang.AFn.applyTo(AFn.java:144)
	at simple.main.main(Unknown Source)
```

cc: @BrunoBonacci, with this patch I was able to run https://github.com/BrunoBonacci/graalvm-clojure/tree/master/ring-jetty.