### PR TITLE
deleted ring-codec in ring-core/project.clj

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -5,7 +5,6 @@
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.7.0"]
-                 [ring/ring-codec "1.1.2"]
                  [commons-io "2.6"]
                  [commons-fileupload "1.4"]
                  [crypto-random "1.2.0"]


### PR DESCRIPTION
It seems `ring-core` does not already need `ring-codec`.