### PR TITLE
Update Jetty to 9.4.24.v20191120

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.8.0"]
                  [ring/ring-servlet "1.8.0"]
-                 [org.eclipse.jetty/jetty-server "9.4.22.v20191022"]]
+                 [org.eclipse.jetty/jetty-server "9.4.24.v20191120"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.10.0"]]


### PR DESCRIPTION
The following issues are fixed in this version:
- https://github.com/eclipse/jetty.project/issues/4279 Regression: ResponseWriter#close blocks indefinitely
- https://github.com/eclipse/jetty.project/issues/4161 Regression: EofException: request lifecycle violation