### PR TITLE
Update stacktrace to include trimmed? and use color? in web

### DIFF
--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -5,117 +5,151 @@
   This middleware is for debugging purposes, and should be limited to
   development environments."
   (:require [clojure.java.io :as io]
+            [clojure.string :as str]
             [hiccup.core :refer [html h]]
             [hiccup.page :refer [html5]]
-            [clj-stacktrace.core :refer :all]
-            [clj-stacktrace.repl :refer :all]
+            [clj-stacktrace.core :refer [parse-exception]]
+            [clj-stacktrace.repl :refer [clojure-method-str
+                                         elem-color
+                                         java-method-str
+                                         pst
+                                         pst-on
+                                         source-str]]
             [ring.util.response :refer [content-type response status]]))
+
+(defn swap-trace-elems
+  "Recursively replace :trace-elems with :trimmed-elems"
+  [exception]
+  (let [trimmed (or (:trimmed-elems exception) '())
+        cause   (:cause exception)]
+    (if cause
+      (assoc exception
+             :cause       (swap-trace-elems cause)
+             :trace-elems trimmed)
+      (assoc exception :trace-elems trimmed))))
+
+(defn trim-error-elems [ex trimmed?]
+  (if trimmed?
+    (swap-trace-elems (parse-exception ex))
+    (parse-exception ex)))
 
 (defn wrap-stacktrace-log
   "Wrap a handler such that exceptions are logged to *err* and then rethrown.
   Accepts the following options:
-
-  :color? - if true, apply ANSI colors to stacktrace (default false)"
+  :color?   - if true, apply ANSI colors to stacktrace (default false)
+  :trimmed? - if true, use the trimmed-elems instead of trace-elems (default false)"
   ([handler]
    (wrap-stacktrace-log handler {}))
   ([handler options]
-   (let [color? (:color? options)]
+   (let [{:keys [color? trimmed?]} options]
      (fn
        ([request]
         (try
           (handler request)
           (catch Throwable ex
-            (pst-on *err* color? ex)
+            (pst-on *err* color? (trim-error-elems ex trimmed?))
             (throw ex))))
        ([request respond raise]
         (try
-          (handler request respond (fn [ex] (pst-on *err* color? ex) (raise ex)))
+          (handler request respond (fn [ex] (pst-on *err* color? (trim-error-elems ex trimmed?)) (raise ex)))
           (catch Throwable ex
-            (pst-on *err* color? ex)
+            (pst-on *err* color? (trim-error-elems ex trimmed?))
             (throw ex))))))))
 
 (defn- style-resource [path]
   (html [:style {:type "text/css"} (slurp (io/resource path))]))
 
-(defn- elem-partial [elem]
+(defn color-style
+  "Returns a style tag with the color appropriate for the given trace elem.
+  Cyan is replaced with black for readability on the light background."
+  [elem]
+  {:style
+   {:color (str/replace (name (elem-color elem)) "cyan" "black")}})
+
+(defn- elem-partial [elem color?]
   (if (:clojure elem)
-    [:tr.clojure
+    [:tr.clojure (when color? (color-style elem))
       [:td.source (h (source-str elem))]
       [:td.method (h (clojure-method-str elem))]]
-    [:tr.java
+    [:tr.java (when color? (color-style elem))
       [:td.source (h (source-str elem))]
       [:td.method (h (java-method-str elem))]]))
 
-(defn- html-exception [ex]
-  (let [[ex & causes] (iterate :cause (parse-exception ex))]
+(defn- html-exception [ex color? trimmed?]
+  (let [[ex & causes] (iterate :cause (trim-error-elems ex trimmed?))]
     (html5
       [:head
         [:title "Ring: Stacktrace"]
         (style-resource "ring/css/stacktrace.css")]
       [:body
         [:div#exception
-          [:h1 (h (.getName ^Class (:class ex)))]
-          [:div.message (h (:message ex))]
+         [:h1 (h (.getName ^Class (:class ex)))]
+         [:div.message (h (:message ex))]
+        (when (pos? (count (:trace-elems ex)))
           [:div.trace
-            [:table
-              [:tbody (map elem-partial (:trace-elems ex))]]]
+           [:table
+            [:tbody (map #(elem-partial % color?) (:trace-elems ex))]]])
          (for [cause causes :while cause]
            [:div#causes
-             [:h2 "Caused by " [:span.class (h (.getName ^Class (:class cause)))]]
-             [:div.message (h (:message cause))]
-             [:div.trace
-               [:table
-                 [:tbody (map elem-partial (:trace-elems cause))]]]])]])))
+            [:h2 "Caused by " [:span.class (h (.getName ^Class (:class cause)))]]
+            [:div.message (h (:message cause))]
+            [:div.trace
+             [:table
+              [:tbody (map #(elem-partial % color?) (:trace-elems cause))]]]])]])))
 
 (defn- text-ex-response [e]
   (-> (response (with-out-str (pst e)))
       (status 500)
       (content-type "text/plain")))
 
-(defn- html-ex-response [ex]
-  (-> (response (html-exception ex))
+(defn- html-ex-response [ex color? trimmed?]
+  (-> (response (html-exception ex color? trimmed?))
       (status 500)
       (content-type "text/html")))
 
 (defn- ex-response
   "Returns a response showing debugging information about the exception.
-
   Renders HTML if that's in the accept header (indicating that the URL was
   opened in a browser), but defaults to plain text."
-  [req ex]
+  [req ex color? trimmed?]
   (let [accept (get-in req [:headers "accept"])]
     (if (and accept (re-find #"^text/html" accept))
-      (html-ex-response ex)
+      (html-ex-response ex color? trimmed?)
       (text-ex-response ex))))
 
 (defn wrap-stacktrace-web
   "Wrap a handler such that exceptions are caught and a response containing
-  a HTML representation of the exception and stacktrace is returned."
-  [handler]
-  (fn
-    ([request]
-     (try
-       (handler request)
-       (catch Throwable ex
-         (ex-response request ex))))
-    ([request respond raise]
-     (try
-       (handler request respond (fn [ex] (respond (ex-response request ex))))
-       (catch Throwable ex
-         (respond (ex-response request ex)))))))
+  a HTML representation of the exception and stacktrace is returned.
+  Accepts the following option:
+  :color?   - if true, apply ANSI colors to terminal stacktrace (default false)
+  :trimmed? - if true, use the trimmed-elems instead of trace-elems (default false)"
+  ([handler]
+   (wrap-stacktrace-web handler {}))
+  ([handler options]
+   (let [{:keys [color? trimmed?]} options]
+     (fn
+       ([request]
+        (try
+          (handler request)
+          (catch Throwable ex
+            (ex-response request ex color? trimmed?))))
+       ([request respond raise]
+        (try
+          (handler request respond (fn [ex] (respond (ex-response request ex color? trimmed?))))
+          (catch Throwable ex
+            (respond (ex-response request ex color? trimmed?)))))))))
 
 (defn wrap-stacktrace
   "Wrap a handler such that exceptions are caught, a corresponding stacktrace is
   logged to *err*, and a HTML representation of the stacktrace is returned as a
   response.
-
   Accepts the following option:
-
-  :color? - if true, apply ANSI colors to terminal stacktrace (default false)"
+  :color?   - if true, apply ANSI colors to terminal stacktrace (default false)
+  :trimmed? - if true, use the trimmed-elems instead of trace-elems (default false)"
   {:arglists '([handler] [handler options])}
   ([handler]
    (wrap-stacktrace handler {}))
   ([handler options]
    (-> handler
        (wrap-stacktrace-log options)
-       (wrap-stacktrace-web))))
+       (wrap-stacktrace-web options))))

--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -8,16 +8,11 @@
             [clojure.string :as str]
             [hiccup.core :refer [html h]]
             [hiccup.page :refer [html5]]
-            [clj-stacktrace.core :refer [parse-exception]]
-            [clj-stacktrace.repl :refer [clojure-method-str
-                                         elem-color
-                                         java-method-str
-                                         pst
-                                         pst-on
-                                         source-str]]
+            [clj-stacktrace.core :refer :all]
+            [clj-stacktrace.repl :refer :all]
             [ring.util.response :refer [content-type response status]]))
 
-(defn swap-trace-elems
+(defn- swap-trace-elems
   "Recursively replace :trace-elems with :trimmed-elems"
   [exception]
   (let [trimmed (or (:trimmed-elems exception) '())
@@ -28,7 +23,7 @@
              :trace-elems trimmed)
       (assoc exception :trace-elems trimmed))))
 
-(defn trim-error-elems [ex trimmed?]
+(defn- trim-error-elems [ex trimmed?]
   (if trimmed?
     (swap-trace-elems (parse-exception ex))
     (parse-exception ex)))
@@ -37,7 +32,7 @@
   "Wrap a handler such that exceptions are logged to *err* and then rethrown.
   Accepts the following options:
   :color?   - if true, apply ANSI colors to stacktrace (default false)
-  :trimmed? - if true, use the trimmed-elems instead of trace-elems (default false)"
+  :trimmed? - if true, use trimmed-elems (default false)"
   ([handler]
    (wrap-stacktrace-log handler {}))
   ([handler options]
@@ -51,7 +46,13 @@
             (throw ex))))
        ([request respond raise]
         (try
-          (handler request respond (fn [ex] (pst-on *err* color? (trim-error-elems ex trimmed?)) (raise ex)))
+          (handler request
+                   respond
+                   (fn [ex]
+                     (pst-on *err*
+                             color?
+                             (trim-error-elems ex trimmed?))
+                     (raise ex)))
           (catch Throwable ex
             (pst-on *err* color? (trim-error-elems ex trimmed?))
             (throw ex))))))))
@@ -59,7 +60,7 @@
 (defn- style-resource [path]
   (html [:style {:type "text/css"} (slurp (io/resource path))]))
 
-(defn color-style
+(defn- color-style
   "Returns a style tag with the color appropriate for the given trace elem.
   Cyan is replaced with black for readability on the light background."
   [elem]
@@ -83,19 +84,20 @@
         (style-resource "ring/css/stacktrace.css")]
       [:body
         [:div#exception
-         [:h1 (h (.getName ^Class (:class ex)))]
-         [:div.message (h (:message ex))]
+          [:h1 (h (.getName ^Class (:class ex)))]
+          [:div.message (h (:message ex))]
         (when (pos? (count (:trace-elems ex)))
           [:div.trace
-           [:table
-            [:tbody (map #(elem-partial % color?) (:trace-elems ex))]]])
+            [:table
+              [:tbody (map #(elem-partial % color?) (:trace-elems ex))]]])
          (for [cause causes :while cause]
            [:div#causes
-            [:h2 "Caused by " [:span.class (h (.getName ^Class (:class cause)))]]
-            [:div.message (h (:message cause))]
-            [:div.trace
-             [:table
-              [:tbody (map #(elem-partial % color?) (:trace-elems cause))]]]])]])))
+             [:h2 "Caused by " [:span.class (h (.getName ^Class (:class cause)))]]
+             [:div.message (h (:message cause))]
+             [:div.trace
+               [:table
+                 [:tbody
+                  (map #(elem-partial % color?) (:trace-elems cause))]]]])]])))
 
 (defn- text-ex-response [e]
   (-> (response (with-out-str (pst e)))
@@ -122,7 +124,7 @@
   a HTML representation of the exception and stacktrace is returned.
   Accepts the following option:
   :color?   - if true, apply ANSI colors to terminal stacktrace (default false)
-  :trimmed? - if true, use the trimmed-elems instead of trace-elems (default false)"
+  :trimmed? - if true, use the trimmed-elems (default false)"
   ([handler]
    (wrap-stacktrace-web handler {}))
   ([handler options]
@@ -135,7 +137,10 @@
             (ex-response request ex color? trimmed?))))
        ([request respond raise]
         (try
-          (handler request respond (fn [ex] (respond (ex-response request ex color? trimmed?))))
+          (handler request
+                   respond
+                   (fn [ex]
+                     (respond (ex-response request ex color? trimmed?))))
           (catch Throwable ex
             (respond (ex-response request ex color? trimmed?)))))))))
 
@@ -144,8 +149,8 @@
   logged to *err*, and a HTML representation of the stacktrace is returned as a
   response.
   Accepts the following option:
-  :color?   - if true, apply ANSI colors to terminal stacktrace (default false)
-  :trimmed? - if true, use the trimmed-elems instead of trace-elems (default false)"
+  :color?   - if true, apply ANSI colors to stacktrace (default false)
+  :trimmed? - if true, use the trimmed-elems (default false)"
   {:arglists '([handler] [handler options])}
   ([handler]
    (wrap-stacktrace handler {}))

--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -111,6 +111,7 @@
 
 (defn- ex-response
   "Returns a response showing debugging information about the exception.
+
   Renders HTML if that's in the accept header (indicating that the URL was
   opened in a browser), but defaults to plain text."
   [req ex color? trimmed?]
@@ -122,8 +123,9 @@
 (defn wrap-stacktrace-web
   "Wrap a handler such that exceptions are caught and a response containing
   a HTML representation of the exception and stacktrace is returned.
+
   Accepts the following option:
-  :color?   - if true, apply ANSI colors to terminal stacktrace (default false)
+  :color?   - if true, apply ANSI colors to HTML stacktrace (default false)
   :trimmed? - if true, use the trimmed-elems (default false)"
   ([handler]
    (wrap-stacktrace-web handler {}))
@@ -148,6 +150,7 @@
   "Wrap a handler such that exceptions are caught, a corresponding stacktrace is
   logged to *err*, and a HTML representation of the stacktrace is returned as a
   response.
+
   Accepts the following option:
   :color?   - if true, apply ANSI colors to stacktrace (default false)
   :trimmed? - if true, use the trimmed-elems (default false)"

--- a/ring-devel/src/ring/middleware/stacktrace.clj
+++ b/ring-devel/src/ring/middleware/stacktrace.clj
@@ -31,6 +31,7 @@
 (defn wrap-stacktrace-log
   "Wrap a handler such that exceptions are logged to *err* and then rethrown.
   Accepts the following options:
+
   :color?   - if true, apply ANSI colors to stacktrace (default false)
   :trimmed? - if true, use trimmed-elems (default false)"
   ([handler]
@@ -125,6 +126,7 @@
   a HTML representation of the exception and stacktrace is returned.
 
   Accepts the following option:
+
   :color?   - if true, apply ANSI colors to HTML stacktrace (default false)
   :trimmed? - if true, use the trimmed-elems (default false)"
   ([handler]
@@ -152,6 +154,7 @@
   response.
 
   Accepts the following option:
+
   :color?   - if true, apply ANSI colors to stacktrace (default false)
   :trimmed? - if true, use the trimmed-elems (default false)"
   {:arglists '([handler] [handler options])}

--- a/ring-devel/test/ring/middleware/test/stacktrace.clj
+++ b/ring-devel/test/ring/middleware/test/stacktrace.clj
@@ -36,28 +36,34 @@
 
 (deftest wrap-stacktrace-cps-test
   (doseq [params [default-params non-default-params]]
-   (testing "no exception"
-     (let [handler   (wrap-stacktrace (fn [_ respond _] (respond :ok)) params)
-           response  (promise)
-           exception (promise)]
-       (handler {} response exception)
-       (is (= :ok @response))
-       (is (not (realized? exception)))))
+    (testing "no exception"
+      (let [handler   (wrap-stacktrace (fn [_ respond _]
+                                         (respond :ok))
+                                       params)
+            response  (promise)
+            exception (promise)]
+        (handler {} response exception)
+        (is (= :ok @response))
+        (is (not (realized? exception)))))
 
-   (testing "thrown exception"
-     (let [handler   (wrap-stacktrace (fn [_ _ _] (throw (Exception. "fail"))) params)
-           response  (promise)
-           exception (promise)]
-       (binding [*err* (java.io.StringWriter.)]
-         (handler {} response exception))
-       (is (= 500 (:status @response)))
-       (is (not (realized? exception)))))
+    (testing "thrown exception"
+      (let [handler   (wrap-stacktrace (fn [_ _ _]
+                                         (throw (Exception. "fail")))
+                                       params)
+            response  (promise)
+            exception (promise)]
+        (binding [*err* (java.io.StringWriter.)]
+          (handler {} response exception))
+        (is (= 500 (:status @response)))
+        (is (not (realized? exception)))))
 
-   (testing "raised exception"
-     (let [handler   (wrap-stacktrace (fn [_ _ raise] (raise (Exception. "fail"))) params)
-           response  (promise)
-           exception (promise)]
-       (binding [*err* (java.io.StringWriter.)]
-         (handler {} response exception))
-       (is (= 500 (:status @response)))
-       (is (not (realized? exception)))))))
+    (testing "raised exception"
+      (let [handler   (wrap-stacktrace (fn [_ _ raise]
+                                         (raise (Exception. "fail")))
+                                       params)
+            response  (promise)
+            exception (promise)]
+        (binding [*err* (java.io.StringWriter.)]
+          (handler {} response exception))
+        (is (= 500 (:status @response)))
+        (is (not (realized? exception)))))))

--- a/ring-devel/test/ring/middleware/test/stacktrace.clj
+++ b/ring-devel/test/ring/middleware/test/stacktrace.clj
@@ -6,8 +6,8 @@
 (def assert-app    (wrap-stacktrace (fn [_] (assert (= 1 2)))))
 
 
-(def html-req  {:headers {"accept" "text/html"}})
-(def js-req    {:headers {"accept" "application/javascript"}})
+(def html-req {:headers {"accept" "text/html"}})
+(def js-req   {:headers {"accept" "application/javascript"}})
 (def plain-req {})
 
 (deftest wrap-stacktrace-smoke
@@ -25,7 +25,7 @@
           (is (or (.startsWith body "java.lang.Exception")
                   (.startsWith body "java.lang.AssertionError")))))
       (testing "requests without Accept header"
-        (let [{:keys [status headers body]} (app plain-req)]
+        (let [{:keys [status headers body]} (app js-req)]
           (is (= 500 status))
           (is (= {"Content-Type" "text/plain"} headers))
           (is (or (.startsWith body "java.lang.Exception")


### PR DESCRIPTION
- I expanded the use of the color? option to show colors on the html response for (wrap-stacktrace-web ) based on the error type (java, clojure, etc).  This uses the same logic for determining color as (wrap-stacktrace-log).

- I also added a new tag trimmed? to use the :trimmed-elems instead of :trace-elems.  :trimmed-elems is a shorter stack trace provided the error report.  You can see an example in current code by comparing the log output and the web output for a :cause.  The log output already uses :trimmed-elems in pst-on.

closes #386