### PR TITLE
Fix typo in test script for stacktrace

### DIFF
--- a/ring-devel/test/ring/middleware/test/stacktrace.clj
+++ b/ring-devel/test/ring/middleware/test/stacktrace.clj
@@ -25,7 +25,7 @@
           (is (or (.startsWith body "java.lang.Exception")
                   (.startsWith body "java.lang.AssertionError")))))
       (testing "requests without Accept header"
-        (let [{:keys [status headers body]} (app js-req)]
+        (let [{:keys [status headers body]} (app plain-req)]
           (is (= 500 status))
           (is (= {"Content-Type" "text/plain"} headers))
           (is (or (.startsWith body "java.lang.Exception")


### PR DESCRIPTION
Fix typo where test was using incorrect header object.   The third test is for a request with no accept header, which is `plain-req`.