### PR TITLE
Fix woff font file mime-type, add woff2

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -88,7 +88,7 @@
    "txt"      "text/plain"
    "webm"     "video/webm"
    "wmv"      "video/x-ms-wmv"
-   "woff"     "application/font-woff"
+   "woff"     "font/woff"
    "xbm"      "image/x-xbitmap"
    "xls"      "application/vnd.ms-excel"
    "xml"      "text/xml"

--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -89,6 +89,7 @@
    "webm"     "video/webm"
    "wmv"      "video/x-ms-wmv"
    "woff"     "font/woff"
+   "woff2"    "font/woff2"
    "xbm"      "image/x-xbitmap"
    "xls"      "application/vnd.ms-excel"
    "xml"      "text/xml"


### PR DESCRIPTION
The mime types for WOFF fonts have been standardized and extended in RFC 8081. Per [RFC 8081 § 4.4.5][1], the old `application/font-woff` should be replaced with `font/woff`.

Ring didn't previously have a definition for WOFF2. This commit adds it per [RFC 8081 § 4.4.6][2]. Including it allows Ring to properly auto-assign content type for files with a .woff2 extension on disk. These are currently going out as a blank content type by default.

[1]: https://tools.ietf.org/html/rfc8081#section-4.4.5
[2]: https://tools.ietf.org/html/rfc8081#section-4.4.6