### PR TITLE
Fix response streaming in case of error

### DIFF
--- a/ring-core/test/ring/core/test/protocols.clj
+++ b/ring-core/test/ring/core/test/protocols.clj
@@ -1,7 +1,8 @@
 (ns ring.core.test.protocols
   (:require [clojure.test :refer :all]
             [clojure.java.io :as io]
-            [ring.core.protocols :refer :all]))
+            [ring.core.protocols :refer :all])
+  (:import [java.io SequenceInputStream IOException InputStream OutputStream]))
 
 (deftest test-write-body-defaults
   (testing "byte-array"
@@ -53,3 +54,41 @@
           response {:body nil}]
       (write-body-to-stream (:body response) response output)
       (is (= "" (.toString output))))))
+
+(defn output-stream-with-close-flag []
+  (let [stream-closed? (atom false)
+        output-stream  (proxy [OutputStream] []
+                         (write
+                           ([])
+                           ([^bytes _])
+                           ([^bytes _ _ _]))
+                         (close [] (reset! stream-closed? true)))]
+    [output-stream stream-closed?]))
+
+(defn error-input-stream []
+  (proxy [InputStream] []
+    (read
+      ([] (throw (IOException. "test error")))
+      ([^bytes _] (throw (IOException. "test error")))
+      ([^bytes _ _ _] (throw (IOException. "test error"))))))
+
+(deftest test-error-when-writing-body
+  (testing "input streams with error"
+    (let [[output closed?] (output-stream-with-close-flag)
+          resource         (io/resource "ring/assets/hello world.txt")
+          input-stream     (SequenceInputStream.
+                            (io/input-stream resource)
+                            (error-input-stream))
+          response         {:body input-stream}]
+      (is (thrown? IOException
+                   (write-body-to-stream (:body response) response output)))
+      (is (= false @closed?))))
+
+  (testing "seqs with error"
+    (let [[output closed?] (output-stream-with-close-flag)
+          response         {:body (lazy-cat
+                                   ["a"]
+                                   (throw (IOException. "test error")))}]
+      (is (thrown? IOException
+                   (write-body-to-stream (:body response) response output)))
+      (is (= false @closed?)))))


### PR DESCRIPTION
OutputStream will not be closed in case of error
so underlying server could handle it properly.
Fixed issue: termination chunk was send after
streaming interruption by error.

Fixes #420.