### PR TITLE
Use font/ttf MIME type for ttf

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -84,7 +84,7 @@
    "tif"      "image/tiff"
    "tiff"     "image/tiff"
    "ts"       "video/mp2t"
-   "ttf"      "application/x-font-ttf"
+   "ttf"      "font/ttf"
    "txt"      "text/plain"
    "webm"     "video/webm"
    "wmv"      "video/x-ms-wmv"


### PR DESCRIPTION
Parallels https://github.com/ring-clojure/ring/pull/421 and follows up https://github.com/ring-clojure/ring/pull/32. I believe this is the correct type, following the same logic as #421 and looking at https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types. I noticed this because Cloudflare wasn't compressing my .ttfs (although it turned out for the better as I was reminded about upgrading them with `woff2_compress`)