### PR TITLE
Add type hint for server to eliminate reflection warning

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -113,7 +113,7 @@
           (.addExcludeProtocols context-server protocols))))
     context-server))
 
-(defn- ^ServerConnector ssl-connector [server options]
+(defn- ^ServerConnector ssl-connector [^Server server options]
   (let [ssl-port     (options :ssl-port 443)
         http-factory (HttpConnectionFactory.
                       (doto (http-config options)


### PR DESCRIPTION
In ssl-connector, Java was not able to resolve server.addBean without a type hint