### PR TITLE
Return correct request urls for proxied requests

### DIFF
--- a/ring-core/src/ring/util/request.clj
+++ b/ring-core/src/ring/util/request.clj
@@ -6,7 +6,8 @@
   "Return the full URL of the request."
   {:added "1.2"}
   [request]
-  (str (-> request :scheme name)
+  (str (or (get-in request [:headers "x-forwarded-proto"])
+           (-> request :scheme name))
        "://"
        (get-in request [:headers "host"])
        (:uri request)

--- a/ring-core/test/ring/util/test/request.clj
+++ b/ring-core/test/ring/util/test/request.clj
@@ -17,7 +17,13 @@
   (is (= (request-url {:scheme :https
                        :uri "/index.html"
                        :headers {"host" "www.example.com"}})
-         "https://www.example.com/index.html")))
+         "https://www.example.com/index.html"))
+  (is (= (request-url {:scheme :http
+                       :uri "/index.html"
+                       :headers {"host" "www.example.com"
+                                 "x-forwarded-proto" "https"}})
+         "https://www.example.com/index.html")
+      "Respect x-forwarded-proto when present"))
 
 (deftest test-content-type
   (testing "no content-type"


### PR DESCRIPTION
We're having problems with `wrap-absolute-redirects` sending the browser to `http:` and the underlying problem is that `ring.util.request/request-url` doesn't take `x-forwarded-proto` into account. I'm happy to move the change into wrap-absolute-redirects or make this fn multi-arity if you think this is too heavy handed.