### PR TITLE
Update Jetty to a newer release without known vulnerabilities

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.9.3"]
                  [ring/ring-servlet "1.9.3"]
-                 [org.eclipse.jetty/jetty-server "9.4.40.v20210413"]]
+                 [org.eclipse.jetty/jetty-server "9.4.42.v20210604"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.10.0"]


### PR DESCRIPTION
The current release of ring-jetty-adapter contains a version of Jetty that has two known vulnerabilities, https://nvd.nist.gov/vuln/detail/CVE-2021-28169 and https://nvd.nist.gov/vuln/detail/CVE-2021-34428. These are fixed in the following Jetty releases. This pull request updates Jetty from 9.4.40 to 9.4.42 which fixes those vulnerabilities.