### PR TITLE
Add stop method for jetty adapter

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -226,3 +226,7 @@
       (catch Exception ex
         (.stop server)
         (throw ex)))))
+
+(defn stop [^Server server]
+  "Stop given `server`"
+  (.stop server))


### PR DESCRIPTION
It is useful for stopping a server without reflection warnings.

```clojure
(ns some-ns
  ...
  (:import
   [org.eclipse.jetty.server Server]))

(defmethod ig/halt-key! ::adapters/jetty [_ ^Server server]
  (.stop server))
```

vs

```clojure
(defmethod ig/halt-key! ::adapters/jetty [_ server]
  (jetty/stop server))
```

or even for lazy loading:

```clojure
(defmethod ig/halt-key! ::adapters/jetty [_ server]
  ((requiring-resolve 'ring.adapter.jetty/stop) server))
```
