### PR TITLE
Fix wrap-content-type for requests of directories

### DIFF
--- a/ring-core/test/ring/middleware/test/content_type.clj
+++ b/ring-core/test/ring/middleware/test/content_type.clj
@@ -1,6 +1,10 @@
 (ns ring.middleware.test.content-type
   (:require [clojure.test :refer :all]
-            [ring.middleware.content-type :refer :all]))
+            [ring.middleware.content-type :refer :all])
+  (:import [java.io File]))
+
+(def public-dir "test/ring/assets")
+(def index-html (File. ^String public-dir "index.html"))
 
 (deftest wrap-content-type-test
   (testing "response without content-type"
@@ -10,6 +14,15 @@
              {:headers {"Content-Type" "image/png"}}))
       (is (= (handler {:uri "/foo/bar.txt"})
              {:headers {"Content-Type" "text/plain"}}))))
+  
+  (testing "response body is java.io.File"
+    (let [response {:headers {}
+                    :body index-html}
+          handler (wrap-content-type (constantly response))]
+      (is (= (get-in (handler {:uri "/index.html"}) [:headers "Content-Type"])
+             "text/html"))
+      (is (= (get-in (handler {:uri "/"}) [:headers "Content-Type"])
+             "text/html"))))
 
   (testing "response with content-type"
     (let [response {:headers {"Content-Type" "application/x-foo"}}


### PR DESCRIPTION
When the request points to a directory and the body of the response is a file (i.e. index.html or something like that), take the mime type of that file. This fixes the case where previously requesting "/" would serve "index.html" with content type "application/octet-stream".

This fixes #408.