### PR TITLE
Update Jetty to version 9.4.44

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.9.4"]
                  [ring/ring-servlet "1.9.4"]
-                 [org.eclipse.jetty/jetty-server "9.4.42.v20210604"]]
+                 [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.12.3"]


### PR DESCRIPTION
CVE-2021-34429 is fixed in version 9.4.43 but it makes sense to
update to the latest 9.x series release with further fixes.