### PR TITLE
Add WEBP to the list of default mime types.

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -87,6 +87,7 @@
    "ttf"      "font/ttf"
    "txt"      "text/plain"
    "webm"     "video/webm"
+   "webp"     "image/webp" 
    "wmv"      "video/x-ms-wmv"
    "woff"     "font/woff"
    "woff2"    "font/woff2"


### PR DESCRIPTION
WEBP has [94% browser support](https://caniuse.com/?search=webp) and is a common way to serve images.