### PR TITLE
Update jetty-server to 9.4.48.v20220622

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.9.5"]
                  [ring/ring-servlet "1.9.5"]
-                 [org.eclipse.jetty/jetty-server "9.4.44.v20210927"]]
+                 [org.eclipse.jetty/jetty-server "9.4.48.v20220622"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.12.3"]


### PR DESCRIPTION
It's been awhile since Jetty's been updated to the latest patch version, and we've been getting low vulnerability CVE warnings. Figured it was worth a PR.