### PR TITLE
Jetty adapter: Move KeyStoreScanner from main namespace

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -15,7 +15,7 @@
            [org.eclipse.jetty.server.handler AbstractHandler]
            [org.eclipse.jetty.util BlockingArrayQueue]
            [org.eclipse.jetty.util.thread ThreadPool QueuedThreadPool]
-           [org.eclipse.jetty.util.ssl SslContextFactory$Server KeyStoreScanner]
+           [org.eclipse.jetty.util.ssl SslContextFactory$Server]
            [javax.servlet AsyncContext DispatcherType AsyncEvent AsyncListener]
            [javax.servlet.http HttpServletRequest HttpServletResponse]))
 
@@ -125,8 +125,7 @@
     (when-let [scan-interval (options :keystore-scan-interval)]
       (.addBean server (do (require '[ring.adapter.util :as u])
                            #_{:clj-kondo/ignore [:unresolved-namespace]}
-                           ((resolve 'u/create-key-store-scanner)
-                            ssl-context scan-interval))))
+                           ((resolve 'u/create-key-store-scanner) ssl-context scan-interval))))
     (doto (server-connector server ssl-factory http-factory)
       (.setPort ssl-port)
       (.setHost (options :host))

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -123,8 +123,10 @@
         ssl-context  (ssl-context-factory options)
         ssl-factory  (SslConnectionFactory. ssl-context "http/1.1")]
     (when-let [scan-interval (options :keystore-scan-interval)]
-      (.addBean server (doto (KeyStoreScanner. ssl-context)
-                         (.setScanInterval scan-interval))))
+      (.addBean server (do (require '[ring.adapter.util :as u])
+                           #_{:clj-kondo/ignore [:unresolved-namespace]}
+                           ((resolve 'u/create-key-store-scanner)
+                            ssl-context scan-interval))))
     (doto (server-connector server ssl-factory http-factory)
       (.setPort ssl-port)
       (.setHost (options :host))

--- a/ring-jetty-adapter/src/ring/adapter/util.clj
+++ b/ring-jetty-adapter/src/ring/adapter/util.clj
@@ -1,0 +1,9 @@
+(ns ring.adapter.util
+  ;; KeyStoreScanner has `LOG` which loads logging during compilation time.
+  ;; This interrupts GraalVM compilation
+  (:import org.eclipse.jetty.util.ssl.KeyStoreScanner))
+
+(defn create-key-store-scanner [ssl-context scan-interval]
+  (doto (KeyStoreScanner. ssl-context)
+    (.setScanInterval scan-interval)))
+


### PR DESCRIPTION
Closes #468 by loading `KeyStoreScanner` lazily