### PR TITLE
Update commons-fileupload to 1.5

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -7,7 +7,7 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-codec "1.2.0"]
                  [commons-io "2.11.0"]
-                 [commons-fileupload "1.4"]
+                 [commons-fileupload "1.5"]
                  [crypto-random "1.2.1"]
                  [crypto-equality "1.0.1"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10" "test"]}


### PR DESCRIPTION
1.5 doesn't contain CVE-2023-24998