### PR TITLE
Add support for serving on Unix domain socket

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -12,7 +12,8 @@
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.12.3"]
-                         [less-awful-ssl "1.0.6"]]
+                         [less-awful-ssl "1.0.6"]
+                         [io.projectreactor.netty/reactor-netty "1.1.5"]]
           :jvm-opts ["-Dorg.eclipse.jetty.server.HttpChannelState.DEFAULT_TIMEOUT=500"]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}

--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,7 +7,8 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.10.0"]
                  [ring/ring-servlet "1.10.0"]
-                 [org.eclipse.jetty/jetty-server "9.4.51.v20230217"]]
+                 [org.eclipse.jetty/jetty-server "9.4.51.v20230217"]
+                 [org.eclipse.jetty/jetty-unixsocket "9.4.51.v20230217"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.12.3"]

--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -168,7 +168,10 @@
 (defn- ^Server create-server [options]
   (let [pool   (or (:thread-pool options) (create-threadpool options))
         server (Server. pool)]
-    (when (:http? options true)
+    (when (:http? options (or ;; default is enabled when no socket specified
+                              (not (:unix-socket options))
+                              ;; enabled with socket when host/port set
+                              (some options [:host :port])))
       (.addConnector server (http-connector server options)))
     (when (or (options :ssl?) (options :ssl-port))
       (.addConnector server (ssl-connector server options)))
@@ -190,13 +193,13 @@
   :join?                  - blocks the thread until server ends
                             (defaults to true)
   :daemon?                - use daemon threads (defaults to false)
-  :http?                  - listen on :port for HTTP traffic (defaults to true)
+  :http?                  - listen on :port for HTTP traffic (defaults to true
+                            unless :unix-socket is set)
   :ssl?                   - allow connections over HTTPS
   :ssl-port               - the SSL port to listen on (defaults to 443, implies
                             :ssl? is true)
-  :unix-socket            - File to be used as a Unix domain socket. will be
-                            passed to [io/file]. Use with `:http? false` to
-                            disable serving on a network port as well.
+  :unix-socket            - File to be used as a Unix domain socket; will be
+                            passed to [io/file]
   :ssl-context            - an optional SSLContext to use for SSL connections
   :exclude-ciphers        - when :ssl? is true, additionally exclude these
                             cipher suites

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -112,7 +112,12 @@
                        (get [_]
                          (DomainSocketAddress. (.getAbsolutePath sock)))))
                    .get (.uri "/") .responseContent .aggregate .asString .block)
-               "Hello World")))))
+               "Hello World")
+            "able to serve basic request")
+        (is (thrown-with-msg?
+              clojure.lang.ExceptionInfo #"File already exists"
+              (run-jetty hello-world {:unix-socket sock, :join? false}))
+            "starting a new server on existing socket should fail"))))
 
   (testing "HTTPS server"
     (with-server hello-world {:port test-port


### PR DESCRIPTION
## Summary
These changes take advantage of `jetty-unixsocket` to allow serving on a socket, as in the following example:

```clojure
(run-jetty handler {:http? false, :socket "/run/someapp.sock"})
```
```bash
## hostname is still required for making requests
curl --unix-socket /run/someapp.sock http://my-expected-hostname/url-path
```

## Rationale
Unix sockets are simpler to implement access controls to than TCP sockets, as you can simply use file permissions. They are supported by common reverse proxies such as Apache and NGINX, and are thus reasonable for exposing a service through a proxy that may be handling authentication, without making that service available to all users on the host machine.

## Possible enhancements:
1. Options for file ownership and access controls
2. A secure-by-default approach might see `:http?` default false when `:socket` is set, unless `:host` or `:port` are explicitly configured.
3. To avoid the additional dependency, socket support could be conditional on manually including the `jetty-unixsocket` library. It is not an overwhelmingly heavy dependency, though.

Note: it has proved nontrivial to get a test working, as clj-http does not support sockets, and the Clojure implementations that I've found do not seem to work as intended out of the box. I have verified that this implementation is operational manually, and I am willing to work through the process of getting a test working as long as you're interested in incorporating this functionality.