### PR TITLE
Add .xlsx extension to the mimetypes map

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -94,6 +94,7 @@
    "woff2"    "font/woff2"
    "xbm"      "image/x-xbitmap"
    "xls"      "application/vnd.ms-excel"
+   "xlsx"     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
    "xml"      "text/xml"
    "xpm"      "image/x-xpixmap"
    "xwd"      "image/x-xwindowdump"


### PR DESCRIPTION
I need this for some tests I'm writing using https://github.com/xeqi/peridot, which in turn uses this. But still would be nice to have if you're serving them with a web server or whatever I think. 

I checked the MIME type and it is in here: https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Common_types and it's what firefox sends when uploading XLSX too.

Thanks for your time!