### PR TITLE
Update the Jetty adapter to version 11.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '8'
+          java-version: '11'
 
       - name: Install clojure tools
         uses: DeLaGuardo/setup-clojure@10.1
@@ -24,6 +24,10 @@ jobs:
           path: ~/.m2/repository
           key: cljdeps-${{ hashFiles('project.clj', 'ring-*/project.clj') }}
           restore-keys: cljdeps-
+
+      - name: Install undeployed Jakarta servlet project locally
+        run: lein install
+        working-directory: ./ring-jakarta-servlet
 
       - name: Run tests
         run: lein sub test-all

--- a/ring-jakarta-servlet/project.clj
+++ b/ring-jakarta-servlet/project.clj
@@ -1,0 +1,16 @@
+(defproject ring/ring-jakarta-servlet "1.10.0"
+  :description "Ring Jakarta servlet utilities."
+  :url "https://github.com/ring-clojure/ring"
+  :scm {:dir ".."}
+  :license {:name "The MIT License"
+            :url "http://opensource.org/licenses/MIT"}
+  :dependencies [[org.clojure/clojure "1.7.0"]
+                 [ring/ring-core "1.10.0"]]
+  :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
+  :profiles
+  {:provided {:dependencies [[jakarta.servlet/jakarta.servlet-api "5.0.0"]]}
+   :dev  {:dependencies [[jakarta.servlet/jakarta.servlet-api "5.0.0"]]}
+   :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
+   :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
+   :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
+   :1.11 {:dependencies [[org.clojure/clojure "1.11.1"]]}})

--- a/ring-jakarta-servlet/src/ring/util/jakarta/servlet.clj
+++ b/ring-jakarta-servlet/src/ring/util/jakarta/servlet.clj
@@ -1,0 +1,161 @@
+(ns ring.util.jakarta.servlet
+  "Compatibility functions for turning a ring handler into a Java servlet."
+  (:require [clojure.string :as string]
+            [ring.core.protocols :as protocols])
+  (:import [java.util Locale]
+           [jakarta.servlet AsyncContext]
+           [jakarta.servlet.http
+            HttpServlet
+            HttpServletRequest
+            HttpServletResponse]))
+
+(defn- get-headers [^HttpServletRequest request]
+  (reduce
+   (fn [headers ^String name]
+     (assoc headers
+            (.toLowerCase name Locale/ENGLISH)
+            (->> (.getHeaders request name)
+                 (enumeration-seq)
+                 (string/join ","))))
+   {}
+   (enumeration-seq (.getHeaderNames request))))
+
+(defn- get-content-length [^HttpServletRequest request]
+  (let [length (.getContentLength request)]
+    (when (>= length 0) length)))
+
+(defn- get-client-cert [^HttpServletRequest request]
+  (first (.getAttribute request "jakarta.servlet.request.X509Certificate")))
+
+(defn build-request-map
+  "Create the request map from the HttpServletRequest object."
+  [^HttpServletRequest request]
+  {:server-port        (.getServerPort request)
+   :server-name        (.getServerName request)
+   :remote-addr        (.getRemoteAddr request)
+   :uri                (.getRequestURI request)
+   :query-string       (.getQueryString request)
+   :scheme             (keyword (.getScheme request))
+   :request-method     (keyword (.toLowerCase (.getMethod request) Locale/ENGLISH))
+   :protocol           (.getProtocol request)
+   :headers            (get-headers request)
+   :content-type       (.getContentType request)
+   :content-length     (get-content-length request)
+   :character-encoding (.getCharacterEncoding request)
+   :ssl-client-cert    (get-client-cert request)
+   :body               (.getInputStream request)})
+
+(defn merge-servlet-keys
+  "Associate servlet-specific keys with the request map for use with legacy
+  systems."
+  [request-map
+   ^HttpServlet servlet
+   ^HttpServletRequest request
+   ^HttpServletResponse response]
+  (merge request-map
+         {:servlet              servlet
+          :servlet-request      request
+          :servlet-response     response
+          :servlet-context      (.getServletContext servlet)
+          :servlet-context-path (.getContextPath request)}))
+
+(defn- set-headers [^HttpServletResponse response, headers]
+  (doseq [[key val-or-vals] headers]
+    (if (string? val-or-vals)
+      (.setHeader response key val-or-vals)
+      (doseq [val val-or-vals]
+        (.addHeader response key val))))
+  ; Some headers must be set through specific methods
+  (when-let [content-type (get headers "Content-Type")]
+    (.setContentType response content-type)))
+
+(defn- make-output-stream
+  [^HttpServletResponse response ^AsyncContext context]
+  (let [os (.getOutputStream response)]
+    (if (nil? context)
+      os
+      (proxy [java.io.FilterOutputStream] [os]
+        (write
+          ([b]         (.write os b))
+          ([b off len] (.write os b off len)))
+        (close []
+          (.close os)
+          (.complete context))))))
+
+(defn update-servlet-response
+  "Update the HttpServletResponse using a response map. Takes an optional
+  AsyncContext."
+  ([response response-map]
+   (update-servlet-response response nil response-map))
+  ([^HttpServletResponse response context response-map]
+   (let [{:keys [status headers body]} response-map]
+     (when (nil? response)
+       (throw (NullPointerException. "HttpServletResponse is nil")))
+     (when (nil? response-map)
+       (throw (NullPointerException. "Response map is nil")))
+     (when status
+       (.setStatus response status))
+     (set-headers response headers)
+     (let [output-stream (make-output-stream response context)]
+       (protocols/write-body-to-stream body response-map output-stream)))))
+
+(defn- make-blocking-service-method [handler]
+  (fn [servlet request response]
+    (-> request
+        (build-request-map)
+        (merge-servlet-keys servlet request response)
+        (handler)
+        (->> (update-servlet-response response)))))
+
+(defn- make-async-service-method [handler]
+  (fn [servlet ^HttpServletRequest request ^HttpServletResponse response]
+    (let [^AsyncContext context (.startAsync request)]
+      (handler
+       (-> request
+           (build-request-map)
+           (merge-servlet-keys servlet request response))
+       (fn [response-map]
+         (update-servlet-response response context response-map))
+       (fn [^Throwable exception]
+         (.sendError response 500 (.getMessage exception))
+         (.complete context))))))
+
+(defn make-service-method
+  "Turns a handler into a function that takes the same arguments and has the
+  same return value as the service method in the HttpServlet class."
+  ([handler]
+   (make-service-method handler {}))
+  ([handler options]
+   (if (:async? options)
+     (make-async-service-method handler)
+     (make-blocking-service-method handler))))
+
+(defn servlet
+  "Create a servlet from a Ring handler."
+  ([handler]
+   (servlet handler {}))
+  ([handler options]
+   (let [service-method (make-service-method handler options)]
+     (proxy [HttpServlet] []
+       (service [request response]
+         (service-method this request response))))))
+
+(defmacro defservice
+  "Defines a service method with an optional prefix suitable for being used by
+  genclass to compile a HttpServlet class.
+
+  For example:
+
+    (defservice my-handler)
+    (defservice \"my-prefix-\" my-handler)"
+  ([handler]
+   `(defservice "-" ~handler))
+  ([prefix handler]
+   (if (map? handler)
+     `(defservice "-" ~prefix ~handler)
+     `(defservice ~prefix ~handler {})))
+  ([prefix handler options]
+   `(let [service-method# (make-service-method ~handler ~options)]
+      (defn ~(symbol (str prefix "service"))
+        [servlet# request# response#]
+        (service-method# servlet# request# response#)))))

--- a/ring-jakarta-servlet/test/ring/util/jakarta/test/servlet.clj
+++ b/ring-jakarta-servlet/test/ring/util/jakarta/test/servlet.clj
@@ -1,0 +1,220 @@
+(ns ring.util.jakarta.test.servlet
+  (:require [clojure.test :refer :all]
+            [ring.util.jakarta.servlet :refer :all]
+            [ring.core.protocols :as proto])
+  (:import [java.util Locale]))
+
+(defmacro ^:private with-locale [locale & body]
+  `(let [old-locale# (Locale/getDefault)]
+     (try (Locale/setDefault ~locale)
+          (do ~@body)
+          (finally (Locale/setDefault old-locale#)))))
+
+(defn- enumeration [coll]
+  (let [e (atom coll)]
+    (proxy [java.util.Enumeration] []
+      (hasMoreElements [] (not (empty? @e)))
+      (nextElement [] (let [f (first @e)] (swap! e rest) f)))))
+
+(defn- async-context [completed]
+  (proxy [jakarta.servlet.AsyncContext] []
+    (complete [] (reset! completed true))))
+
+(defn- servlet-request [request]
+  (let [attributes {"jakarta.servlet.request.X509Certificate"
+                    [(request :ssl-client-cert)]}]
+    (proxy [jakarta.servlet.http.HttpServletRequest] []
+      (getServerPort [] (request :server-port))
+      (getServerName [] (request :server-name))
+      (getRemoteAddr [] (request :remote-addr))
+      (getRequestURI [] (request :uri))
+      (getQueryString [] (request :query-string))
+      (getContextPath [] (request :servlet-context-path))
+      (getScheme [] (name (request :scheme)))
+      (getMethod [] (-> request :request-method name .toUpperCase))
+      (getProtocol [] (request :protocol))
+      (getHeaderNames [] (enumeration (keys (request :headers))))
+      (getHeaders [name] (enumeration (get-in request [:headers name])))
+      (getContentType [] (request :content-type))
+      (getContentLength [] (or (request :content-length) -1))
+      (getCharacterEncoding [] (request :character-encoding))
+      (getAttribute [k] (attributes k))
+      (getInputStream [] (request :body))
+      (startAsync [] (async-context (request :completed))))))
+
+(defn- servlet-response [response]
+  (let [output-stream (java.io.ByteArrayOutputStream.)]
+    (swap! response assoc :body output-stream)
+    (proxy [jakarta.servlet.http.HttpServletResponse] []
+      (getOutputStream []
+        (proxy [jakarta.servlet.ServletOutputStream] []
+          (write
+            ([b] (.write output-stream b))
+            ([b off len] (.write output-stream b off len)))))
+      (setStatus [status]
+        (swap! response assoc :status status))
+      (setHeader [name value]
+        (swap! response assoc-in [:headers name] value))
+      (setCharacterEncoding [value])
+      (setContentType [value]
+        (swap! response assoc :content-type value)))))
+
+(defn- servlet-config []
+  (proxy [jakarta.servlet.ServletConfig] []
+    (getServletContext [] nil)))
+
+(defn- run-servlet
+  ([handler request response]
+   (run-servlet handler request response {}))
+  ([handler request response options]
+   (doto (servlet handler options)
+     (.init (servlet-config))
+     (.service (servlet-request request)
+               (servlet-response response)))))
+
+(deftest make-service-method-test
+  (let [handler (constantly {:status  201
+                             :headers {}})
+        method  (make-service-method handler)
+        servlet (doto (proxy [jakarta.servlet.http.HttpServlet] [])
+                  (.init (servlet-config)))
+        request {:server-port    8080
+                 :server-name    "foobar"
+                 :remote-addr    "127.0.0.1"
+                 :uri            "/foo"
+                 :scheme         :http
+                 :request-method :get
+                 :protocol       "HTTP/1.1"
+                 :headers        {}}
+        response (atom {})]
+    (method servlet (servlet-request request) (servlet-response response))
+    (is (= (@response :status) 201))))
+
+(deftest servlet-test
+  (let [body (proxy [jakarta.servlet.ServletInputStream] [])
+        cert (proxy [java.security.cert.X509Certificate] [])
+        request {:server-port    8080
+                 :server-name    "foobar"
+                 :remote-addr    "127.0.0.1"
+                 :uri            "/foo"
+                 :query-string   "a=b"
+                 :scheme         :http
+                 :request-method :get
+                 :protocol       "HTTP/1.1"
+                 :headers        {"X-Client" ["Foo", "Bar"]
+                                  "X-Server" ["Baz"]
+                                  "X-Capital-I" ["Qux"]}
+                 :content-type   "text/plain"
+                 :content-length 10
+                 :character-encoding "UTF-8"
+                 :servlet-context-path "/foo"
+                 :ssl-client-cert cert
+                 :body            body}
+          response (atom {})]
+    (letfn [(handler [r]
+             (are [k v] (= (r k) v)
+               :server-port    8080
+               :server-name    "foobar"
+               :remote-addr    "127.0.0.1"
+               :uri            "/foo"
+               :query-string   "a=b"
+               :scheme         :http
+               :request-method :get
+               :protocol       "HTTP/1.1"
+               :headers        {"x-client" "Foo,Bar"
+                                "x-server" "Baz"
+                                "x-capital-i" "Qux"}
+               :content-type   "text/plain"
+               :content-length 10
+               :character-encoding "UTF-8"
+               :servlet-context-path "/foo"
+               :ssl-client-cert cert
+               :body            body)
+             {:status 200, :headers {}})]
+      (testing "request"
+        (run-servlet handler request response))
+      (testing "mapping request header names to lower case"
+        (with-locale (Locale. "tr")
+          (run-servlet handler request response))))
+    (testing "response"
+      (letfn [(handler [r]
+               {:status  200
+                :headers {"Content-Type" "text/plain"
+                          "X-Server" "Bar"}
+                :body    "Hello World"})]
+        (run-servlet handler request response)
+        (is (= (@response :status) 200))
+        (is (= (@response :content-type) "text/plain"))
+        (is (= (get-in @response [:headers "X-Server"]) "Bar"))
+        (is (= (.toString (@response :body)) "Hello World"))))))
+
+(deftest servlet-cps-test
+  (let [handler  (fn [_ respond _]
+                   (respond {:status  200
+                             :headers {"Content-Type" "text/plain"}
+                             :body    "Hello World"}))
+        request  {:completed      (atom false)
+                  :server-port    8080
+                  :server-name    "foobar"
+                  :remote-addr    "127.0.0.1"
+                  :uri            "/foo"
+                  :scheme         :http
+                  :request-method :get
+                  :protocol       "HTTP/1.1"
+                  :headers        {}
+                  :body           nil}
+        response (atom {})]
+    (run-servlet handler request response {:async? true})
+    (is (= @(:completed request) true))
+    (is (= (@response :status) 200))
+    (is (= (@response :content-type) "text/plain"))
+    (is (= (.toString (@response :body)) "Hello World"))))
+
+(defn- defservice-test* [service]
+  (let [body     (proxy [jakarta.servlet.ServletInputStream] [])
+        servlet  (doto (proxy [jakarta.servlet.http.HttpServlet] [])
+                   (.init (servlet-config)))
+        request  {:server-port    8080
+                  :server-name    "foobar"
+                  :remote-addr    "127.0.0.1"
+                  :uri            "/foo"
+                  :query-string   ""
+                  :scheme         :http
+                  :request-method :get
+                  :headers        {}
+                  :content-type   "text/plain"
+                  :content-length 10
+                  :character-encoding "UTF-8"
+                  :body           body}
+        response (atom {})]
+    (service servlet
+             (servlet-request request)
+             (servlet-response response))
+    (is (= (@response :status) 200))
+    (is (= (get-in @response [:headers "Content-Type" ]) "text/plain"))
+    (is (= (.toString (@response :body)) "Hello World"))))
+
+(defn- service-handler [_]
+  {:status  200
+   :headers {"Content-Type" "text/plain"}
+   :body    "Hello World"})
+
+(defservice "foo-" service-handler)
+(defservice service-handler {})
+
+(deftest defservice-test
+  (defservice-test* foo-service)
+  (defservice-test* -service))
+
+(deftest make-output-stream-test
+  (let [response (atom {})]
+    (update-servlet-response
+     (servlet-response response)
+     (async-context (atom false))
+     {:status  200
+      :headers {}
+      :body    (reify proto/StreamableResponseBody
+                 (write-body-to-stream [_ _ os]
+                   (.write os (int \h))
+                   (.write os (.getBytes "ello"))))})
+    (is (= "hello" (.toString (:body @response))))))

--- a/ring-jetty-adapter/checkouts/ring-jakarta-servlet
+++ b/ring-jetty-adapter/checkouts/ring-jakarta-servlet
@@ -1,0 +1,1 @@
+../../ring-jakarta-servlet/

--- a/ring-jetty-adapter/checkouts/ring-servlet
+++ b/ring-jetty-adapter/checkouts/ring-servlet
@@ -1,1 +1,0 @@
-../../ring-servlet

--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -6,8 +6,8 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.10.0"]
-                 [ring/ring-servlet "1.10.0"]
-                 [org.eclipse.jetty/jetty-server "9.4.51.v20230217"]]
+                 [ring/ring-jakarta-servlet "1.10.0"]
+                 [org.eclipse.jetty/jetty-server "11.0.15"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.12.3"]

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -82,12 +82,13 @@
   (doto (KeyStore/getInstance (KeyStore/getDefaultType)) (.load nil)))
 
 (def test-ssl-options
-  {:port         test-port
-   :ssl?         true
-   :ssl-port     test-ssl-port
-   :keystore     nil-keystore
-   :key-password "hunter2"
-   :join?        false})
+  {:port            test-port
+   :ssl?            true
+   :ssl-port        test-ssl-port
+   :keystore        nil-keystore
+   :key-password    "hunter2"
+   :join?           false
+   :sni-host-check? false})
 
 (deftest test-run-jetty
   (testing "HTTP server"
@@ -102,7 +103,8 @@
     (with-server hello-world {:port test-port
                               :ssl-port test-ssl-port
                               :keystore "test/keystore.jks"
-                              :key-password "password"}
+                              :key-password "password"
+                              :sni-host-check? false}
       (let [response (http/get test-ssl-url {:insecure? true})]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello World")))))
@@ -122,7 +124,8 @@
                               :port test-port
                               :ssl-port test-ssl-port
                               :keystore "test/keystore.jks"
-                              :key-password "password"}
+                              :key-password "password"
+                              :sni-host-check? false}
       (let [response (http/get test-ssl-url {:insecure? true})]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello World")))
@@ -135,7 +138,8 @@
                                       :key-password "password"
                                       :port test-port
                                       :ssl? true
-                                      :ssl-port test-ssl-port}
+                                      :ssl-port test-ssl-port
+                                      :sni-host-check? false}
       (is (thrown? java.io.IOException
                    (http/get test-ssl-url {:insecure? true}))
           "missing client certs will cause an exception")
@@ -153,7 +157,8 @@
                                       :key-password "password"
                                       :port test-port
                                       :ssl? true
-                                      :ssl-port test-ssl-port}
+                                      :ssl-port test-ssl-port
+                                      :sni-host-check? false}
       (let [response (http/get test-ssl-url {:insecure? true
                                              :throw-exceptions false})]
         (is (= 403 (:status response))
@@ -169,7 +174,8 @@
   (testing "HTTPS server using :ssl-context"
     (with-server hello-world {:port test-port
                               :ssl-port test-ssl-port
-                              :ssl-context (ssl-context)}
+                              :ssl-context (ssl-context)
+                              :sni-host-check? false}
       (let [response (http/get test-ssl-url {:insecure? true})]
         (is (= (:status response) 200))
         (is (= (:body response) "Hello World")))))
@@ -179,7 +185,8 @@
                                       :ssl-context (ssl-context)
                                       :port test-port
                                       :ssl? true
-                                      :ssl-port test-ssl-port}
+                                      :ssl-port test-ssl-port
+                                      :sni-host-check? false}
       (is (thrown? java.io.IOException
                    (http/get test-ssl-url {:insecure? true}))
           "missing client certs will cause an exception")
@@ -196,7 +203,8 @@
                                       :ssl-context (ssl-context)
                                       :port test-port
                                       :ssl? true
-                                      :ssl-port test-ssl-port}
+                                      :ssl-port test-ssl-port
+                                      :sni-host-check? false}
       (let [response (http/get test-ssl-url {:insecure? true
                                              :throw-exceptions false})]
         (is (= 403 (:status response))
@@ -243,7 +251,8 @@
                                          :keystore "test/keystore.jks"
                                          :key-password "password"
                                          :join? false
-                                         :max-idle-time 5000})
+                                         :max-idle-time 5000
+                                         :sni-host-check? false})
           connectors (. server getConnectors)]
       (is (= 5000 (. (first connectors) getIdleTimeout)))
       (is (= 5000 (. (second connectors) getIdleTimeout)))
@@ -254,6 +263,7 @@
                                          :ssl-port test-ssl-port
                                          :keystore "test/keystore.jks"
                                          :key-password "password"
+                                         :sni-host-check? false
                                          :join? false})
           connectors (. server getConnectors)]
       (is (= 200000 (. (first connectors) getIdleTimeout)))

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -604,16 +604,17 @@
   (swap! call-count inc)
   (raise (ex-info "unhandled exception" {})))
 
-(testing "broken handler is only called once"
-  (reset! call-count 0)
-  (with-server broken-handler {:port test-port}
-    (try (http/get test-url)
-      (catch Exception _ nil))
-    (is (= 1 @call-count))))
+(deftest broken-handler-test
+  (testing "broken handler is only called once"
+    (reset! call-count 0)
+    (with-server broken-handler {:port test-port}
+      (try (http/get test-url)
+           (catch Exception _ nil))
+      (is (= 1 @call-count))))
 
-(testing "broken async handler is only called once"
-  (reset! call-count 0)
-  (with-server broken-handler-cps {:async? true :port test-port}
-    (try (http/get test-url)
-      (catch Exception _ nil))
-    (is (= 1 @call-count))))
+  (testing "broken async handler is only called once"
+    (reset! call-count 0)
+    (with-server broken-handler-cps {:async? true :port test-port}
+      (try (http/get test-url)
+           (catch Exception _ nil))
+      (is (= 1 @call-count)))))


### PR DESCRIPTION
This closes #439 and increases the minimum required Java version from 8 to 11.

A new project, ring-jakarta-servlet has been also added, as Jetty 11.0 requires Jakarta Servlet 5.0, which has changed package names (javax.servlet -> jakarta.servlet). A new project was created in order to allow the existing ring-servlet project to maintain backward compatibility.