### PR TITLE
Replace FileUpload 1.5 with FileUpload 2.0.0-M1

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -7,14 +7,12 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-codec "1.2.0"]
                  [commons-io "2.13.0"]
-                 [commons-fileupload "1.5"]
+                 [org.apache.commons/commons-fileupload2-core "2.0.0-M1"]
                  [crypto-random "1.2.1"]
                  [crypto-equality "1.0.1"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
-  {:provided {:dependencies [[javax.servlet/servlet-api "2.5"]]}
-   :dev  {:dependencies [[clj-time "0.15.2"]
-                         [javax.servlet/servlet-api "2.5"]]}
+  {:dev  {:dependencies [[clj-time "0.15.2"]]}
    :1.8  {:dependencies [[org.clojure/clojure "1.8.0"]]}
    :1.9  {:dependencies [[org.clojure/clojure "1.9.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}

--- a/ring-core/test/ring/middleware/test/multipart_params.clj
+++ b/ring-core/test/ring/middleware/test/multipart_params.clj
@@ -192,7 +192,7 @@
         handler       (constantly {:status 200, :headers {}, :body "OK"})
         handler-async (fn [_ respond _]
                         (respond {:status 200, :headers {}, :body "OK"}))]
-    (is (thrown? org.apache.commons.fileupload.FileUploadBase$FileUploadIOException
+    (is (thrown? org.apache.commons.fileupload2.core.FileUploadException
                  (multipart-params-request
                   {:headers headers, :body (string-input-stream form-body)}
                   {:max-file-size 6})))


### PR DESCRIPTION
The Apache Commons FileUpload library has released 2.0.0-M1, the first milestone release of 2.0.0. In this version, the core package of the library no longer has a dependency on the Servlet API, which means we can eliminate this problematic dependency from Ring core, once there is a full release of FileUpload 2.0.0.

Milestone 2 should be along in a couple of weeks.