### PR TITLE
fix: websocket multi-value connection upgrades

### DIFF
--- a/ring-core/src/ring/websocket.clj
+++ b/ring-core/src/ring/websocket.clj
@@ -66,9 +66,11 @@
 (defn upgrade-request?
   "Returns true if the request map is a websocket upgrade request."
   [request]
-  (let [headers (:headers request)]
-    (and (.equalsIgnoreCase "upgrade" (get headers "connection"))
-         (.equalsIgnoreCase "websocket" (get headers "upgrade")))))
+  (let [{{:strs [connection upgrade]} :headers} request]
+    (and upgrade
+         connection
+         (re-find #"\b(?i)upgrade\b" connection)
+         (.equalsIgnoreCase "websocket" upgrade))))
 
 (defn websocket-response?
   "Returns true if the response contains a websocket listener."

--- a/ring-core/test/ring/test/websocket.clj
+++ b/ring-core/test/ring/test/websocket.clj
@@ -3,6 +3,14 @@
             [ring.websocket :as ws]
             [ring.websocket.protocols :as wsp]))
 
+
+(deftest test-upgrade-request?
+  (is (not (ws/upgrade-request? {})))
+  (is (ws/upgrade-request? {:headers {"connection" "Upgrade"
+                                      "upgrade"    "websocket"}}))
+  (is (ws/upgrade-request? {:headers {"connection" "keep-alive, Upgrade"
+                                      "upgrade"    "websocket"}})))
+
 (deftest test-request-protocols
   (is (empty? (ws/request-protocols {:headers {}})))
   (is (= ["mqtt"]


### PR DESCRIPTION
Fixes an issue where browsers could send `keep-alive` and `Upgrade` in the same request causing the `ws/upgrade-request?` to return false.