### PR TITLE
Add support for Partitioned/CHIPS cookies

### DIFF
--- a/ring-core/src/ring/middleware/cookies.clj
+++ b/ring-core/src/ring/middleware/cookies.clj
@@ -21,7 +21,7 @@
 (def ^:private set-cookie-attrs
   {:domain "Domain", :max-age "Max-Age", :path "Path"
    :secure "Secure", :expires "Expires", :http-only "HttpOnly"
-   :same-site "SameSite"})
+   :same-site "SameSite", :partitioned "Partitioned"})
 
 (def ^:private same-site-values
   {:strict "Strict", :lax "Lax", :none "None"})

--- a/ring-core/test/ring/middleware/test/cookies.clj
+++ b/ring-core/test/ring/middleware/test/cookies.clj
@@ -103,6 +103,13 @@
     (is (= {"Set-Cookie" (list "a=b" "c=d")}
            (:headers resp)))))
 
+(deftest wrap-cookies-set-partitioned
+  (let [response {:cookies {"a" {:value "foo" :partitioned true}}}
+        handler  (constantly response)
+        resp     ((wrap-cookies handler) {})]
+    (is (= {"Set-Cookie" #{"a=foo" "Partitioned"}}
+           (split-set-cookie (:headers resp))))))
+
 (deftest wrap-cookies-invalid-attrs
   (let [response {:cookies {"a" {:value "foo" :invalid true}}}
         handler  (wrap-cookies (constantly response))]


### PR DESCRIPTION
Adds simple support for [Partitioned cookies](https://developer.mozilla.org/en-US/docs/Web/Privacy/Partitioned_cookies). Does no validation (requiring `:secure`). I briefly considered it, but that felt like a step too far.

Closes #492