### PR TITLE
Update Jetty dependency to 11.0.20

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -7,8 +7,8 @@
   :dependencies [[org.clojure/clojure "1.7.0"]
                  [ring/ring-core "1.11.0"]
                  [org.ring-clojure/ring-jakarta-servlet "1.11.0"]
-                 [org.eclipse.jetty/jetty-server "11.0.18"]
-                 [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.18"]]
+                 [org.eclipse.jetty/jetty-server "11.0.20"]
+                 [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.20"]]
   :aliases {"test-all" ["with-profile" "default:+1.8:+1.9:+1.10:+1.11" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.12.3"]


### PR DESCRIPTION
This version contains a fix for CVE-2024-22201.