### PR TITLE
patch ring to support graal

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -1,4 +1,4 @@
-(defproject ring/ring-core "1.12.2"
+(defproject ring/ring-core "1.12.2-patched-graal"
   :description "Ring core libraries."
   :url "https://github.com/ring-clojure/ring"
   :scm {:dir ".."}

--- a/ring-core/src/ring/util/response.clj
+++ b/ring-core/src/ring/util/response.clj
@@ -297,6 +297,14 @@
        :content-length (connection-content-length conn)
        :last-modified  (connection-last-modified conn)})))
 
+(defmethod resource-data :resource
+  [^java.net.URL url]
+  ;; GraalVM resource scheme
+  (let [resource     (.openConnection url)]
+    {:content        (.getInputStream resource)
+     :content-length (connection-content-length resource)
+     :last-modified  (connection-last-modified resource)}))
+
 (defn url-response
   "Return a response for the supplied URL."
   {:added "1.2"}


### PR DESCRIPTION
This PR: https://github.com/ring-clojure/ring/pull/447

Patch ring, to incorporate into reitit-ring, which clj-widget-api uses.