### PR TITLE
Add "docx" mime-type to mime_type.clj

### DIFF
--- a/ring-core/src/ring/util/mime_type.clj
+++ b/ring-core/src/ring/util/mime_type.clj
@@ -26,6 +26,7 @@
    "dmg"      "application/octet-stream"
    "dms"      "application/octet-stream"
    "doc"      "application/msword"
+   "docx"     "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
    "dvi"      "application/x-dvi"
    "edn"      "application/edn"
    "eot"      "application/vnd.ms-fontobject"


### PR DESCRIPTION
"docx" was missing from the supported mime-types.