### PR TITLE
Add unix domain socket support

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -8,6 +8,7 @@
                  [ring/ring-core "1.12.2"]
                  [org.ring-clojure/ring-jakarta-servlet "1.12.2"]
                  [org.eclipse.jetty/jetty-server "11.0.21"]
+                 [org.eclipse.jetty/jetty-unixdomain-server "11.0.21"]
                  [org.eclipse.jetty.websocket/websocket-jetty-server "11.0.21"]]
   :aliases {"test-all" ["with-profile" "default:+1.10:+1.11:+1.12" "test"]}
   :profiles
@@ -15,6 +16,7 @@
                          [less-awful-ssl "1.0.6"]
                          [hato "0.9.0"]]
           :jvm-opts ["-Dorg.eclipse.jetty.server.HttpChannelState.DEFAULT_TIMEOUT=500"]}
+   :test {:dependencies [[org.eclipse.jetty/jetty-client "11.0.21"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.2"]]}
    :1.12 {:dependencies [[org.clojure/clojure "1.12.0-alpha9"]]}})


### PR DESCRIPTION
Similar to PR #478, although this now uses the new Unix Domain Socket Support in Jetty through `jetty-unixdomain-server`
https://webtide.com/unixdomain-support-in-jetty/

Usage of the new APIs is documented here:
https://jetty.org/docs/jetty/11/programming-guide/server/http.html#connector
https://jetty.org/docs/jetty/11/programming-guide/client/http.html#transport-unix-domain