### PR TITLE
Add SSE support in similar way ring supports WS

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -21,7 +21,8 @@
                          "ring-jetty-adapter/src"
                          "ring-servlet/src"
                          "ring-jakarta-servlet/src"
-                         "ring-websocket-protocols/src"]}
+                         "ring-websocket-protocols/src"
+                         "ring-sse-protocols/src"]}
   :aliases {"test"     ["sub" "test"]
             "test-all" ["sub" "test-all"]
             "bench"    ["sub" "-s" "ring-bench" "run"]

--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -7,6 +7,7 @@
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [org.ring-clojure/ring-core-protocols "1.15.2"]
                  [org.ring-clojure/ring-websocket-protocols "1.15.2"]
+                 [org.ring-clojure/ring-sse-protocols "1.15.2"]
                  [ring/ring-codec "1.3.0"]
                  [commons-io "2.20.0"]
                  [org.apache.commons/commons-fileupload2-core "2.0.0-M4"]

--- a/ring-core/src/ring/sse.clj
+++ b/ring-core/src/ring/sse.clj
@@ -1,0 +1,23 @@
+(ns ring.sse
+  "Protocols and utility functions for SSE support."
+  (:refer-clojure :exclude [send])
+  (:require [ring.sse.protocols :as p]))
+
+
+(extend-type clojure.lang.IPersistentMap
+  p/Listener
+  (on-open [m sender]
+    (when-let [kv (find m :on-open)] ((val kv) sender))))
+
+
+(defn send
+  "Sends a SSE message"
+  [sender sso-message]
+  (p/-send sender sso-message))
+
+
+(defn sse-response?
+  "Returns true if the response contains a SSE emitter."
+  [response]
+  (contains? response ::listener))
+

--- a/ring-jakarta-servlet/src/ring/util/jakarta/servlet.clj
+++ b/ring-jakarta-servlet/src/ring/util/jakarta/servlet.clj
@@ -59,7 +59,7 @@
           :servlet-context      (.getServletContext servlet)
           :servlet-context-path (.getContextPath request)}))
 
-(defn- set-headers [^HttpServletResponse response, headers]
+(defn set-headers [^HttpServletResponse response, headers]
   (doseq [[key val-or-vals] headers]
     (if (string? val-or-vals)
       (.setHeader response key val-or-vals)
@@ -69,7 +69,7 @@
   (when-let [content-type (get headers "Content-Type")]
     (.setContentType response content-type)))
 
-(defn- make-output-stream
+(defn make-output-stream
   [^HttpServletResponse response ^AsyncContext context]
   (let [os (.getOutputStream response)]
     (if (nil? context)

--- a/ring-sse-protocols/project.clj
+++ b/ring-sse-protocols/project.clj
@@ -1,0 +1,9 @@
+(defproject org.ring-clojure/ring-sse-protocols "1.15.2"
+  :description "Ring protocols for SSE."
+  :url "https://github.com/ring-clojure/ring"
+  :scm {:dir ".."}
+  :license {:name "The MIT License"
+            :url "http://opensource.org/licenses/MIT"}
+  :dependencies []
+  :profiles
+  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}})

--- a/ring-sse-protocols/src/ring/sse/protocols.clj
+++ b/ring-sse-protocols/src/ring/sse/protocols.clj
@@ -1,0 +1,12 @@
+(ns ring.sse.protocols)
+
+
+(defprotocol Listener
+  "A protocol for handling SSE responses. The second argument is an object that 
+   satisfies the SSESender protocol."
+  (on-open [listener sse-sender] "Called when the SSE response is opened and ready."))
+
+
+(defprotocol Sender
+  "A protocol for sending SSE responses."
+  (-send [sender message] "Sends a SSE message"))


### PR DESCRIPTION
This PR introduces protocols for SSE support and a reference implementation for `ring.adapter.jetty`.