### PR TITLE
Fix reflection warnings in the ring.adapter.jetty namespace

### DIFF
--- a/ring-jetty-adapter/src/ring/adapter/jetty.clj
+++ b/ring-jetty-adapter/src/ring/adapter/jetty.clj
@@ -21,7 +21,7 @@
            [org.eclipse.jetty.util BlockingArrayQueue]
            [org.eclipse.jetty.util.thread ThreadPool QueuedThreadPool]
            [org.eclipse.jetty.util.ssl SslContextFactory$Server KeyStoreScanner]
-           [org.eclipse.jetty.ee9.nested Request]
+           [org.eclipse.jetty.ee9.nested Request Response]
            [org.eclipse.jetty.ee9.websocket.server
             JettyServerUpgradeRequest
             JettyServerUpgradeResponse
@@ -110,7 +110,7 @@
 
 (defn- proxy-handler ^ServletHandler [handler options]
   (proxy [ServletHandler] []
-    (doHandle [_ ^Request base-request request response]
+    (doHandle [_ ^Request base-request request ^Response response]
       (let [request-map  (servlet/build-request-map request)
             response-map (handler request-map)]
         (try
@@ -209,7 +209,7 @@
 (defn- ssl-context-factory ^SslContextFactory$Server [options]
   (let [context-server (SslContextFactory$Server.)]
     (if (string? (options :keystore))
-      (.setKeyStorePath context-server (options :keystore))
+      (.setKeyStorePath context-server ^String (options :keystore))
       (.setKeyStore context-server ^java.security.KeyStore (options :keystore)))
     (when (string? (options :keystore-type))
       (.setKeyStoreType context-server (options :keystore-type)))


### PR DESCRIPTION
Because it reflects, the `ring.adapter.jetty/proxy-handler` function showed up quite prominently on a [recording](https://en.wikipedia.org/wiki/JDK_Flight_Recorder) of an app running in production.

This change fixes all reflection warnings in the `ring.adapter.jetty` namespace.

Would you be willing to entertain a PR that enables reflection warnings throughout the project, either via `:global-vars {*warn-on-reflection* true}` or `(set! *warn-on-reflection* true)` at the top of every namespace that does Java interop (perhaps coupled with the [`:warn-on-reflection` clj-kondo linter](https://github.com/clj-kondo/clj-kondo/blob/50870acbaf8beb917db4047fe4160a20948f923d/doc/linters.md#warn-on-reflection))?