### PR TITLE
Enable reflection warnings globally and fix reflection warnings in tests

### DIFF
--- a/ring-bench/project.clj
+++ b/ring-bench/project.clj
@@ -9,4 +9,5 @@
                  [ring/ring-jetty-adapter "1.15.2"]
                  [ring/ring-servlet "1.15.2"]]
   :jvm-opts {}
-  :main ring.bench.servlet)
+  :main ring.bench.servlet
+  :global-vars {*warn-on-reflection* true})

--- a/ring-core-protocols/project.clj
+++ b/ring-core-protocols/project.clj
@@ -6,4 +6,5 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies []
   :profiles
-  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}})
+  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -17,4 +17,5 @@
   {:dev  {:dependencies [[clj-time "0.15.2"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
-   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}})
+   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/ring-core/test/ring/middleware/multipart_params/test/byte_array.clj
+++ b/ring-core/test/ring/middleware/multipart_params/test/byte_array.clj
@@ -11,4 +11,4 @@
                  :stream (string-input-stream "foo")})]
     (is (= (:filename result) "foo.txt"))
     (is (= (:content-type result) "text/plain"))
-    (is (= (String. (:bytes result)) "foo"))))
+    (is (= (String. ^bytes (:bytes result)) "foo"))))

--- a/ring-core/test/ring/middleware/multipart_params/test/request_context.clj
+++ b/ring-core/test/ring/middleware/multipart_params/test/request_context.clj
@@ -1,7 +1,8 @@
 (ns ring.middleware.multipart-params.test.request-context
   (:require [clojure.test :refer :all]
-            [ring.middleware.multipart-params :as mp]))
+            [ring.middleware.multipart-params :as mp])
+  (:import [org.apache.commons.fileupload2.core RequestContext]))
 
 (deftest test-default-content-length
   (is (= -1
-         (.getContentLength (#'mp/request-context {} nil)))))
+         (.getContentLength ^RequestContext (#'mp/request-context {} nil)))))

--- a/ring-core/test/ring/middleware/multipart_params/test/temp_file.clj
+++ b/ring-core/test/ring/middleware/multipart_params/test/temp_file.clj
@@ -1,7 +1,8 @@
 (ns ring.middleware.multipart-params.test.temp-file
   (:require [clojure.test :refer :all]
             [ring.middleware.multipart-params.temp-file :refer :all]
-            [ring.util.io :refer [string-input-stream]]))
+            [ring.util.io :refer [string-input-stream]])
+  (:import [java.io File]))
 
 (deftest test-temp-file-store
   (let [store  (temp-file-store)
@@ -12,11 +13,11 @@
     (is (= (:filename result) "foo.txt"))
     (is (= (:content-type result) "text/plain"))
     (is (= (:size result) 3))
-    (is (instance? java.io.File (:tempfile result)))
-    (is (.exists (:tempfile result)))
+    (is (instance? File (:tempfile result)))
+    (is (.exists ^File (:tempfile result)))
     (is (= (slurp (:tempfile result)) "foo"))))
 
-(defn eventually [check n d]
+(defn eventually [check n ^long d]
   (loop [i n]
     (if (check)
       true
@@ -30,9 +31,9 @@
                 {:filename "foo.txt"
                  :content-type "text/plain"
                  :stream (string-input-stream "foo")})]
-    (is (.exists (:tempfile result)))
+    (is (.exists ^File (:tempfile result)))
     (Thread/sleep 2000)
-    (let [deleted? (eventually #(not (.exists (:tempfile result))) 120 250)]
+    (let [deleted? (eventually #(not (.exists ^File (:tempfile result))) 120 250)]
       (is deleted?))))
 
 (defn all-threads []

--- a/ring-core/test/ring/middleware/session/test/cookie.clj
+++ b/ring-core/test/ring/middleware/session/test/cookie.clj
@@ -3,7 +3,9 @@
             [ring.middleware.session.store :refer :all]
             [ring.middleware.session.cookie :as cookie :refer [cookie-store]]
             [ring.util.codec :as codec]
-            [crypto.random :as random]))
+            [crypto.random :as random])
+  (:import [java.io Writer]
+           [java.time Instant]))
 
 (deftest cookie-session-read-not-exist
   (let [store (cookie-store)]
@@ -58,14 +60,14 @@
        (cookie-store {:key (.getBytes "012345678901234567890")}))))
 
 ; setup for serializing/deserializing Instant.
-(defmethod print-method java.time.Instant [dt out]
+(defmethod print-method Instant [^Instant dt ^Writer out]
   (.write out (str "#foo/instant \"" (.toString dt) "\"")))
 
-(defn parse-instant [x] (java.time.Instant/parse x))
+(defn parse-instant [x] (Instant/parse x))
 
 (deftest cookie-session-custom-type
   (let [store    (cookie-store {:readers {'foo/instant #'parse-instant}})
-        now      (java.time.Instant/now)
+        now      (Instant/now)
         sess-key (write-session store nil {:foo now})]
     (is (not (nil? sess-key)))
     (is (= (read-session store sess-key)

--- a/ring-core/test/ring/middleware/test/file.clj
+++ b/ring-core/test/ring/middleware/test/file.clj
@@ -10,9 +10,9 @@
   (is (thrown-with-msg? Exception #".*Directory does not exist.*"
                         (wrap-file (constantly test-response) "not_here"))))
 
-(def public-dir "test/ring/assets")
-(def index-html (File. ^String public-dir "index.html"))
-(def foo-html   (File. ^String public-dir "foo.html"))
+(def ^String public-dir "test/ring/assets")
+(def index-html (File. public-dir "index.html"))
+(def foo-html   (File. public-dir "foo.html"))
 
 (def app (wrap-file (constantly test-response) public-dir))
 

--- a/ring-core/test/ring/middleware/test/file_info.clj
+++ b/ring-core/test/ring/middleware/test/file_info.clj
@@ -15,10 +15,11 @@
   "Lets us use a known file modification time for tests, without permanently changing
    the file's modification time."
   [[file new-time] form]
-  `(let [old-time# (.lastModified ~file)]
-     (.setLastModified ~file ~(* new-time 1000))
-     (try ~form
-          (finally (.setLastModified ~file old-time#)))))
+  (let [file (vary-meta file assoc :tag `File)]
+    `(let [old-time# (.lastModified ~file)]
+       (.setLastModified ~file ~(* new-time 1000))
+       (try ~form
+         (finally (.setLastModified ~file old-time#))))))
 
 (def custom-type-app
   (wrap-file-info

--- a/ring-core/test/ring/middleware/test/multipart_params.clj
+++ b/ring-core/test/ring/middleware/test/multipart_params.clj
@@ -161,7 +161,7 @@
                  :body (string-input-stream form-body)}
         response (handler request)]
     (let [upload (get-in response [:multipart-params "upload"])]
-      (is (java.util.Arrays/equals (:bytes upload) (.getBytes "foo"))))))
+      (is (java.util.Arrays/equals ^bytes (:bytes upload) (.getBytes "foo"))))))
 
 (deftest forced-encoding-option-works
   (let [form-body (str "--XXXX\r\n"

--- a/ring-core/test/ring/middleware/test/resource.clj
+++ b/ring-core/test/ring/middleware/test/resource.clj
@@ -24,7 +24,7 @@
 (deftest resource-loader-test
   (let [root-loader (->> (Thread/currentThread)
                          .getContextClassLoader
-                         (iterate (memfn getParent))
+                         (iterate (memfn ^ClassLoader getParent))
                          (take-while identity)
                          last)
         jarfile     (io/file "test/resource.jar")

--- a/ring-core/test/ring/middleware/test/session.clj
+++ b/ring-core/test/ring/middleware/test/session.clj
@@ -24,10 +24,10 @@
 (defn get-cookies [response]
   (get-in response [:headers "Set-Cookie"]))
 
-(defn is-session-cookie? [c]
+(defn is-session-cookie? [^String c]
   (.contains c "ring-session="))
 
-(defn get-session-cookie [response]
+(defn get-session-cookie ^String [response]
   (first (filter is-session-cookie? (get-cookies response))))
 
 (deftest session-is-read

--- a/ring-devel/project.clj
+++ b/ring-devel/project.clj
@@ -4,6 +4,7 @@
   :scm {:dir ".."}
   :license {:name "The MIT License"
             :url "http://opensource.org/licenses/MIT"}
+  :managed-dependencies [[org.clojure/tools.reader "1.5.2"]]
   :dependencies [[org.clojure/clojure "1.9.0"]
                  [ring/ring-core "1.15.2"]
                  [hiccup "2.0.0"]

--- a/ring-devel/project.clj
+++ b/ring-devel/project.clj
@@ -13,4 +13,5 @@
   :profiles
   {:1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
-   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}})
+   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/ring-devel/test/ring/middleware/test/stacktrace.clj
+++ b/ring-devel/test/ring/middleware/test/stacktrace.clj
@@ -13,18 +13,18 @@
   (binding [*err* (java.io.StringWriter.)]
     (doseq [app [exception-app assert-app]]
       (testing "requests with Accept: text/html"
-        (let [{:keys [status headers body]} (app html-req)]
+        (let [{:keys [status headers ^String body]} (app html-req)]
           (is (= 500 status))
           (is (= {"Content-Type" "text/html"} headers))
           (is (.startsWith body "<!DOCTYPE html>"))))
       (testing "requests with Accept: application/javascript"
-        (let [{:keys [status headers body]} (app js-req)]
+        (let [{:keys [status headers ^String body]} (app js-req)]
           (is (= 500 status))
           (is (= {"Content-Type" "text/plain"} headers))
           (is (or (.startsWith body "java.lang.Exception")
                   (.startsWith body "java.lang.AssertionError")))))
       (testing "requests without Accept header"
-        (let [{:keys [status headers body]} (app plain-req)]
+        (let [{:keys [status headers ^String body]} (app plain-req)]
           (is (= 500 status))
           (is (= {"Content-Type" "text/plain"} headers))
           (is (or (.startsWith body "java.lang.Exception")

--- a/ring-jakarta-servlet/project.clj
+++ b/ring-jakarta-servlet/project.clj
@@ -12,4 +12,5 @@
    :dev  {:dependencies [[jakarta.servlet/jakarta.servlet-api "5.0.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
-   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}})
+   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/ring-jakarta-servlet/src/ring/util/jakarta/servlet.clj
+++ b/ring-jakarta-servlet/src/ring/util/jakarta/servlet.clj
@@ -129,9 +129,9 @@
 
 (defn servlet
   "Create a servlet from a Ring handler."
-  ([handler]
+  (^HttpServlet [handler]
    (servlet handler {}))
-  ([handler options]
+  (^HttpServlet [handler options]
    (let [service-method (make-service-method handler options)]
      (proxy [HttpServlet] []
        (service [request response]

--- a/ring-jakarta-servlet/test/ring/util/jakarta/test/servlet.clj
+++ b/ring-jakarta-servlet/test/ring/util/jakarta/test/servlet.clj
@@ -2,7 +2,8 @@
   (:require [clojure.test :refer :all]
             [ring.util.jakarta.servlet :refer :all]
             [ring.core.protocols :as proto])
-  (:import [java.util Locale]))
+  (:import [java.io OutputStream]
+           [java.util Locale]))
 
 (defmacro ^:private with-locale [locale & body]
   `(let [old-locale# (Locale/getDefault)]
@@ -49,7 +50,10 @@
       (getOutputStream []
         (proxy [jakarta.servlet.ServletOutputStream] []
           (write
-            ([b] (.write output-stream b))
+            ([b]
+             (if (bytes? b)
+               (.write output-stream ^bytes b)
+               (.write output-stream ^int b)))
             ([b off len] (.write output-stream b off len)))))
       (setStatus [status]
         (swap! response assoc :status status))
@@ -146,7 +150,7 @@
         (is (= (@response :status) 200))
         (is (= (@response :content-type) "text/plain"))
         (is (= (get-in @response [:headers "X-Server"]) "Bar"))
-        (is (= (.toString (@response :body)) "Hello World"))))))
+        (is (= (.toString ^OutputStream (@response :body)) "Hello World"))))))
 
 (deftest servlet-cps-test
   (let [handler  (fn [_ respond _]
@@ -168,7 +172,7 @@
     (is (= @(:completed request) true))
     (is (= (@response :status) 200))
     (is (= (@response :content-type) "text/plain"))
-    (is (= (.toString (@response :body)) "Hello World"))))
+    (is (= (.toString ^OutputStream (@response :body)) "Hello World"))))
 
 (defn- defservice-test* [service]
   (let [body     (proxy [jakarta.servlet.ServletInputStream] [])
@@ -192,7 +196,7 @@
              (servlet-response response))
     (is (= (@response :status) 200))
     (is (= (get-in @response [:headers "Content-Type"]) "text/plain"))
-    (is (= (.toString (@response :body)) "Hello World"))))
+    (is (= (.toString ^OutputStream (@response :body)) "Hello World"))))
 
 (defn- service-handler [_]
   {:status  200
@@ -215,6 +219,6 @@
       :headers {}
       :body    (reify proto/StreamableResponseBody
                  (write-body-to-stream [_ _ os]
-                   (.write os (int \h))
-                   (.write os (.getBytes "ello"))))})
-    (is (= "hello" (.toString (:body @response))))))
+                   (.write ^OutputStream os (int \h))
+                   (.write ^OutputStream os (.getBytes "ello"))))})
+    (is (= "hello" (.toString ^OutputStream (:body @response))))))

--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -21,4 +21,5 @@
    :test {:dependencies [[org.eclipse.jetty/jetty-client "12.1.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
-   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}})
+   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/ring-servlet/project.clj
+++ b/ring-servlet/project.clj
@@ -12,4 +12,5 @@
    :dev  {:dependencies [[javax.servlet/javax.servlet-api "3.1.0"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
-   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}})
+   :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}}
+  :global-vars {*warn-on-reflection* true})

--- a/ring-servlet/src/ring/util/servlet.clj
+++ b/ring-servlet/src/ring/util/servlet.clj
@@ -129,9 +129,9 @@
 
 (defn servlet
   "Create a servlet from a Ring handler."
-  ([handler]
+  (^HttpServlet [handler]
    (servlet handler {}))
-  ([handler options]
+  (^HttpServlet [handler options]
    (let [service-method (make-service-method handler options)]
      (proxy [HttpServlet] []
        (service [request response]

--- a/ring-websocket-protocols/project.clj
+++ b/ring-websocket-protocols/project.clj
@@ -6,4 +6,5 @@
             :url "http://opensource.org/licenses/MIT"}
   :dependencies []
   :profiles
-  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}})
+  {:dev {:dependencies [[org.clojure/clojure "1.9.0"]]}}
+  :global-vars {*warn-on-reflection* true})


### PR DESCRIPTION
As of this change, `lein test` yields no reflection warnings.