### PR TITLE
Update FileUpload dependency to 2.0.0-M5

### DIFF
--- a/ring-core/project.clj
+++ b/ring-core/project.clj
@@ -9,7 +9,7 @@
                  [org.ring-clojure/ring-websocket-protocols "1.15.3"]
                  [ring/ring-codec "1.3.0"]
                  [commons-io "2.20.0"]
-                 [org.apache.commons/commons-fileupload2-core "2.0.0-M4"]
+                 [org.apache.commons/commons-fileupload2-core "2.0.0-M5"]
                  [crypto-random "1.2.1"]
                  [crypto-equality "1.0.1"]]
   :aliases {"test-all" ["with-profile" "default:+1.10:+1.11:+1.12" "test"]}

--- a/ring-core/src/ring/middleware/multipart_params.clj
+++ b/ring-core/src/ring/middleware/multipart_params.clj
@@ -30,7 +30,7 @@
 
 (defn- file-upload [request {:keys [progress-fn max-file-size]}]
   (doto (proxy [AbstractFileUpload] [])
-    (.setFileSizeMax (or max-file-size -1))
+    (.setMaxFileSize (or max-file-size -1))
     (set-progress-listener request progress-fn)))
 
 (defn- multipart-form? [request]


### PR DESCRIPTION
Thanks for your continued work on ring!

This PR updates `org.apache.commons/commons-fileupload2-core` to `2.0.0-M5` from Feb 17, 2026 to address a CVE in `2.0.0-M4`.

Background: The currently used version `2.0.0-M4` of `org.apache.commons/commons-fileupload2-core` is, via its own dependencies, vulnerable to [CVE-2025-48924](https://www.cve.org/CVERecord?id=CVE-2025-48924) (StackOverflowError on very long inputs).

References:
- https://mvnrepository.com/artifact/org.apache.commons/commons-fileupload2/2.0.0-M4 (lists the vulnerability)