### PR TITLE
Update Jetty to 12.1.8 (fixes #550)

### DIFF
--- a/ring-jetty-adapter/project.clj
+++ b/ring-jetty-adapter/project.clj
@@ -8,17 +8,17 @@
   [[org.clojure/clojure "1.9.0"]
    [ring/ring-core "1.15.3"]
    [org.ring-clojure/ring-jakarta-servlet "1.15.3"]
-   [org.eclipse.jetty/jetty-server "12.1.0"]
-   [org.eclipse.jetty/jetty-unixdomain-server "12.1.0"]
-   [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.0"]
-   [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server "12.1.0"]]
+   [org.eclipse.jetty/jetty-server "12.1.8"]
+   [org.eclipse.jetty/jetty-unixdomain-server "12.1.8"]
+   [org.eclipse.jetty.ee9/jetty-ee9-servlet "12.1.8"]
+   [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server "12.1.8"]]
   :aliases {"test-all" ["with-profile" "default:+1.10:+1.11:+1.12" "test"]}
   :profiles
   {:dev  {:dependencies [[clj-http "3.13.1"]
                          [less-awful-ssl "1.0.7"]
                          [hato "1.0.0"]]
           :jvm-opts ["-Dorg.eclipse.jetty.server.HttpChannelState.DEFAULT_TIMEOUT=500"]}
-   :test {:dependencies [[org.eclipse.jetty/jetty-client "12.1.0"]]}
+   :test {:dependencies [[org.eclipse.jetty/jetty-client "12.1.8"]]}
    :1.10 {:dependencies [[org.clojure/clojure "1.10.3"]]}
    :1.11 {:dependencies [[org.clojure/clojure "1.11.4"]]}
    :1.12 {:dependencies [[org.clojure/clojure "1.12.1"]]}}

--- a/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
+++ b/ring-jetty-adapter/test/ring/adapter/test/jetty.clj
@@ -816,8 +816,8 @@
                       (on-close [_ _ _ _])
                       wsp/PingListener
                       (on-ping [_ sock data]
-                        (ws/pong sock data)
-                        (swap! log conj [:ping (buf->str data)])))})]
+                        (swap! log conj [:ping (buf->str (.duplicate data))])
+                        (ws/pong sock data)))})]
       (with-server handler {:port test-port}
         (let [ws @(hato/websocket test-websocket-url
                                   {:on-pong


### PR DESCRIPTION
This PR updates Jetty to `12.1.8` to address two CVEs.

CVEs:

- [CVE-2026-1605](https://nvd.nist.gov/vuln/detail/CVE-2026-1605) (high)
- [CVE-2025-11143](https://nvd.nist.gov/vuln/detail/CVE-2025-11143) (medium)

<details><summary>Details</summary>
<p>

```
Dependency Information
-----------------------------------------------------
NAME: org.eclipse.jetty.websocket/jetty-websocket-core-server
VERSION: 12.1.0

DEPENDENCY FOUND IN:

[ring/ring-jetty-adapter]
        [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server]
                [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-servlet]


FIX SUGGESTION:
Vulnerabilities
-----------------------------------------------------

SEVERITY: MEDIUM
IDENTIFIERS: CVE-2025-11143
CVSS: 6.5 (version 3.1)
PATCHED VERSION: 12.1.5

SEVERITY: HIGH
IDENTIFIERS: CVE-2026-1605
CVSS: 7.5 (version 3.1)
PATCHED VERSION: 12.1.6

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@

Dependency Information
-----------------------------------------------------
NAME: org.eclipse.jetty.websocket/jetty-websocket-core-common
VERSION: 12.1.0

DEPENDENCY FOUND IN:

[ring/ring-jetty-adapter]
        [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server]
                [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-common]

[ring/ring-jetty-adapter]
        [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-jetty-server]
                [org.eclipse.jetty.ee9.websocket/jetty-ee9-websocket-servlet]
                        [org.eclipse.jetty.websocket/jetty-websocket-core-server]


FIX SUGGESTION:
Vulnerabilities
-----------------------------------------------------

SEVERITY: MEDIUM
IDENTIFIERS: CVE-2025-11143
CVSS: 6.5 (version 3.1)
PATCHED VERSION: 12.1.5

SEVERITY: HIGH
IDENTIFIERS: CVE-2026-1605
CVSS: 7.5 (version 3.1)
PATCHED VERSION: 12.1.6

@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@


Dependencies scanned: 47
Vulnerable dependencies found: 2 (2 High)
```

</p>
</details> 

Related issues:
- https://github.com/ring-clojure/ring/issues/550 (this PR addresses this issue)